### PR TITLE
Throw exception when vertex id is overflowed

### DIFF
--- a/FreeGroup/include/slp_vertex.h
+++ b/FreeGroup/include/slp_vertex.h
@@ -255,7 +255,7 @@ class NonterminalVertex : public Vertex {
       assert(height() > 1);
       assert(length() > 1);
 
-      if (last_vertex_id_ == 0) {
+      if (last_vertex_id_ <= 0) {
         throw std::overflow_error("NonterminalVertex::vertex_id is overflowed");
       }
     }


### PR DESCRIPTION
I think that since we are running experiments for several days, the vertex id can be actually overflowed and this could cause problems. Please, use NonterminalVertex::reset_vertex_id() between the experiments, where you are sure that the next set of vertices will not interact with any previous ones. 
