### PR TITLE
Refactored code to eliminate template parameters named TerminalSymbol

### DIFF
--- a/FreeGroup/Makefile
+++ b/FreeGroup/Makefile
@@ -32,7 +32,7 @@ LOCAL_LIBS = -L/lib/ -Wl,-Bstatic -lgmpxx -lgmp -Wl,-Bdynamic -ltcmalloc_minimal
 
 # 
 # SRC: lists all source files
-SRC = WhiteheadGraph FreeGroup StraightLineProgramWord StraightLineProgramWord_operators StraightLineProgramWord_truncate StraightLineProgramWord_split slp slp_recompression
+SRC = WhiteheadGraph FreeGroup StraightLineProgramWord StraightLineProgramWord_operators StraightLineProgramWord_truncate StraightLineProgramWord_split slp slp_recompression EndomorphismSLP
 
 
 # 

--- a/FreeGroup/include/AAGCrypto.h
+++ b/FreeGroup/include/AAGCrypto.h
@@ -38,8 +38,8 @@ namespace aag_crypto {
   };
 
 
-  typedef EndomorphismSLP<int> Aut;
-  typedef AutomorphismDescription<Aut > AutDescription;
+  typedef EndomorphismSLP Aut;
+  typedef AutomorphismDescription<Aut> AutDescription;
 
 
   class PublicKey {
@@ -284,7 +284,7 @@ namespace aag_crypto {
       const SchemeParameters params_;
       RandomEngine* p_rand_;
       std::uniform_int_distribution<typename RandomEngine::result_type> length_distr_;
-      UniformAutomorphismSLPGenerator<int, RandomEngine> aut_generator_;
+      UniformAutomorphismSLPGenerator<RandomEngine> aut_generator_;
 
 //      template<typename Iterator>
 //      Aut combine_keys()

--- a/FreeGroup/include/EndomorphismSLP.h
+++ b/FreeGroup/include/EndomorphismSLP.h
@@ -41,11 +41,11 @@ class AutomorphismDescription;
 
 /**
  * Represents a free group endomorphism using straight-line programs.
- * @tparam TerminalSymbol terminal symbols class
  */
-template<typename TerminalSymbol = int>
 class EndomorphismSLP {
 public:
+  typedef slp::TerminalSymbol TerminalSymbol;
+  typedef slp::TerminalVertex TerminalVertex;
 
   typedef typename std::map<TerminalSymbol, slp::Vertex>::size_type size_type;
   typedef typename std::map<TerminalSymbol, slp::Vertex>::iterator iterator;
@@ -147,6 +147,12 @@ public:
   //! Compose with the given endomorphism.
   EndomorphismSLP& operator*=(const EndomorphismSLP& a);
 
+  //! Compose with the given endomorphism.
+  EndomorphismSLP operator*(const EndomorphismSLP& a) const {
+    return EndomorphismSLP(*this) *= a;
+  }
+
+
   //! Compose with endomorphisms specified by the range.
   template<typename Iterator>
   EndomorphismSLP& compose_with(Iterator begin, Iterator end) {
@@ -205,10 +211,7 @@ public:
   }
 
   //! Conjugate with the automorphisms given by the description.
-  EndomorphismSLP conjugate_with(const AutomorphismDescription<EndomorphismSLP>& conjugator) const {
-    return conjugator() * (*this) * conjugator.inverse();
-  }
-
+  EndomorphismSLP conjugate_with(const AutomorphismDescription<EndomorphismSLP>& conjugator) const;
   //! Returns the automorphisms inverse
   /**
    * Currently supporsts only inverter and left and right multipliers.
@@ -260,9 +263,9 @@ public:
   EndomorphismSLP normal_form() const;
 
   //! Returns the image of the terminal.
-  slp::VertexWord<TerminalSymbol> image_word(const TerminalSymbol& t) const {
+  slp::VertexWord image_word(const TerminalSymbol& t) const {
     bool is_positive = is_positive_terminal_symbol(t);
-    return slp::VertexWord<TerminalSymbol>(is_positive ? image(t) : image(-t).negate());
+    return slp::VertexWord(is_positive ? image(t) : image(-t).negate());
   }
 
   //! Returns the root of the straight-line program representing the positive terminal symbol.
@@ -361,8 +364,6 @@ public:
   void print(std::ostream* out) const;
 
 private:
-  typedef typename slp::TerminalVertexTemplate<TerminalSymbol> TerminalVertex;
-
   //! Checks whether the symbol is not inverse.
   static bool is_positive_terminal_symbol(const TerminalSymbol& symbol) {
     static const TerminalSymbol null_symbol = TerminalSymbol();
@@ -406,44 +407,33 @@ private:
 //---------------------------------------------------------------------
 // Helper functions.
 
-//! Compose given endomorphisms.
-template<typename TerminalSymbol>
-EndomorphismSLP<TerminalSymbol> operator*(const EndomorphismSLP<TerminalSymbol>& e1, const EndomorphismSLP<TerminalSymbol>& e2) {
-  return EndomorphismSLP<TerminalSymbol>(e1) *= e2;
-}
-
-
 //! Find the maximal height of SLPs, representing the endomorphism
-template<typename TerminalSymbol>
-unsigned int height(const EndomorphismSLP<TerminalSymbol>& e);
+unsigned int height(const EndomorphismSLP& e);
 
 
 //! Find the total number of vertices in SLPs, representing the endomorphism
-template<typename TerminalSymbol>
-unsigned int slp_vertices_num(const EndomorphismSLP<TerminalSymbol>& e);
+unsigned int slp_vertices_num(const EndomorphismSLP& e);
 
 
 //! Find the total number of vertices in SLPs, representing the endomorphism
-template<typename TerminalSymbol>
-unsigned int slp_unique_images_num(const EndomorphismSLP<TerminalSymbol>& e);
+unsigned int slp_unique_images_num(const EndomorphismSLP& e);
 
 
 //! Returns the map contatining the lengths of non-trivial images (actually some of the images might be trivial).
-template<typename TerminalSymbol>
-std::map<TerminalSymbol, LongInteger> images_length(const EndomorphismSLP<TerminalSymbol>& e);
+std::map<slp::TerminalSymbol, LongInteger> images_length(const EndomorphismSLP& e);
 
 
 //! Automorphisms generator
 /**
- * @tparam TerminalSymbol          terminal symbol representation. We suppose it has a constructor taking index
  * @tparam RandomEngine            engine generating uniformly random non-negative numbers. See std::random library documentation.
- * @tparam TerminalSymbolIndexType terminal symbol index type
  */
-template <typename TerminalSymbol = int,
-  typename RandomEngine = std::default_random_engine>
+template <
+  typename RandomEngine = std::default_random_engine
+>
 class UniformAutomorphismSLPGenerator {
 public:
   typedef int index_type;
+  typedef slp::TerminalSymbol TerminalSymbol;
 
   //! Constructs a generator of automorphisms of the free group of the given rank.
   /**
@@ -507,11 +497,11 @@ public:
   }
 
   //! Generates a random automorphism.
-  EndomorphismSLP<TerminalSymbol> operator()() {
+  EndomorphismSLP operator()() {
     double p = real_distr_(*random_engine_);
     if (p <= inverters_probability_) {//generate an inverter
       index_type val = inverter_distr_(*random_engine_);
-      return EndomorphismSLP<TerminalSymbol>::inverter(TerminalSymbol(MIN_SYMBOL_INDEX + val));
+      return EndomorphismSLP::inverter(TerminalSymbol(MIN_SYMBOL_INDEX + val));
     } else {//generate a multiplier
       index_type val = multiplier_distr_(*random_engine_);
       const bool right_multiplier = (val % 2) == 0;
@@ -522,9 +512,9 @@ public:
       const TerminalSymbol multiplier(multiplier_index < mapped_symbol_index ? multiplier_index : multiplier_index + 1);
 
       if (right_multiplier)
-        return EndomorphismSLP<TerminalSymbol>::right_multiplier(mapped_symbol, multiplier);
+        return EndomorphismSLP::right_multiplier(mapped_symbol, multiplier);
       else
-        return EndomorphismSLP<TerminalSymbol>::left_multiplier(multiplier, mapped_symbol);
+        return EndomorphismSLP::left_multiplier(multiplier, mapped_symbol);
     }
   }
 
@@ -570,7 +560,7 @@ private:
 
 
 //! Automorphism description keeping track of the automorphisms and its inverse.
-template<typename Automorphism = EndomorphismSLP<int> >
+template<typename Automorphism = EndomorphismSLP>
 class AutomorphismDescription {
   public:
 
@@ -696,8 +686,7 @@ class AutomorphismReducer { //todo replace logging to std::cout by logging facil
           std::cout << slp_vertices_num(aut()) << "," << slp_vertices_num(aut.inverse());
         }
 
-        template<typename TerminalSymbol>
-        void operator()(const EndomorphismSLP<TerminalSymbol>& aut) const {
+        void operator()(const EndomorphismSLP& aut) const {
           std::cout << slp_vertices_num(aut);
         }
     };
@@ -790,26 +779,24 @@ class CommutatorSet {
 };
 
 //-------------------------------------------------------------------------------------
-// Implementation of EndomorphismSLP methods.
+// Implementation of templated EndomorphismSLP methods.
 
 
-template<typename TerminalSymbol>
 template<typename Func>
-void EndomorphismSLP<TerminalSymbol>::for_each_basic_morphism(int rank, Func f) {
+void EndomorphismSLP::for_each_basic_morphism(int rank, Func f) {
   assert(rank > 0);
   for (int i = 1; i <= rank; ++i)
-    f(EndomorphismSLP<TerminalSymbol>::inverter(i));
+    f(EndomorphismSLP::inverter(i));
   for (int i = 1; i <= rank; ++i)
     for (int j = -static_cast<int>(rank); j <= rank; ++j)
       if (j != i && j != -i && j != 0) {
-        f(EndomorphismSLP<TerminalSymbol>::left_multiplier(j, i));
-        f(EndomorphismSLP<TerminalSymbol>::right_multiplier(i, j));
+        f(EndomorphismSLP::left_multiplier(j, i));
+        f(EndomorphismSLP::right_multiplier(i, j));
       }
 }
 
-template<typename TerminalSymbol>
 template<typename Func>
-void EndomorphismSLP<TerminalSymbol>::for_each_multiplication(int rank, Func f) {
+void EndomorphismSLP::for_each_multiplication(int rank, Func f) {
   assert(rank > 0);
   const int lower_bound = -static_cast<int>(rank);
   for (int i = lower_bound; i <= rank; ++i) {
@@ -820,571 +807,15 @@ void EndomorphismSLP<TerminalSymbol>::for_each_multiplication(int rank, Func f) 
       if (j == 0 || j == i || j == -i) {
         continue;
       }
-      f(EndomorphismSLP<TerminalSymbol>::multiplication(i, j, true));
-      f(EndomorphismSLP<TerminalSymbol>::multiplication(i, j, false));
+      f(EndomorphismSLP::multiplication(i, j, true));
+      f(EndomorphismSLP::multiplication(i, j, false));
     }
   }
 }
 
 
 
-template <typename TerminalSymbol>
-EndomorphismSLP<TerminalSymbol> EndomorphismSLP<TerminalSymbol>::inverse() const {
-  if (images_.size() == 0) //identity
-    return *this;
-  if (images_.size() > 1)
-    throw std::invalid_argument("Unsupported endomorphism with more than one non-trivial terminal image!");
 
-  auto img = images_.begin();
-  TerminalSymbol symbol = img->first;
-  slp::Vertex image = img->second;
-  if (image.height() > 2)
-    throw std::invalid_argument("Unsupported endomorphism with unsupported slp height > 2!");
-
-  if (image.height() == 1) {//inverter
-    return *this;
-  }
-
-  TerminalVertex left(image.left_child());
-  TerminalVertex right(image.right_child());
-
-  TerminalSymbol left_symbol = left.terminal_symbol();
-  TerminalSymbol right_symbol = right.terminal_symbol();
-
-  if (! (left_symbol == symbol || right_symbol == symbol))
-    throw std::invalid_argument("Unsupported endomorphism not mapping the symbol to the product of another one and itself!");
-
-  if (left_symbol == symbol) {
-    return right_multiplier(symbol, -right_symbol);
-  } else {
-    return left_multiplier(-left_symbol, symbol);
-  }
-}
-
-template <typename TerminalSymbol>
-bool EndomorphismSLP<TerminalSymbol>::operator==(const EndomorphismSLP<TerminalSymbol>& a) const {
-  if (this == &a)
-    return true;
-  if (non_trivial_images_num() != a.non_trivial_images_num())
-    return false;
-  auto images = non_trivial_images_range();
-  auto a_images = a.non_trivial_images_range();
-
-  //checking that the same letters have non-trivial images
-  auto img_iterator = images_.begin();
-  auto a_img_iterator = a.images_.begin();
-  while (img_iterator != images_.end()) {
-    if (img_iterator->first != a_img_iterator->first)
-      return false;
-    ++img_iterator;
-    ++a_img_iterator;
-  }
-
-  //checking that the images are the same
-  slp::MatchingTable mt;
-  img_iterator = images_.begin();
-  a_img_iterator = a.images_.begin();
-  while (img_iterator != images_.end()) {
-    slp::VertexWord<TerminalSymbol> word(img_iterator->second);
-    slp::VertexWord<TerminalSymbol> a_word(a_img_iterator->second);
-    if (!word.is_equal_to(a_word, &mt))
-      return false;
-    ++img_iterator;
-    ++a_img_iterator;
-  }
-
-  return true;
-}
-
-template <typename TerminalSymbol>
-EndomorphismSLP<TerminalSymbol>& EndomorphismSLP<TerminalSymbol>::operator*=(const EndomorphismSLP<TerminalSymbol>& a) {
-  std::unordered_map<slp::Vertex, slp::Vertex> new_vertices;//a's vertices to new vertices correspondence
-
-  for (const auto& root_entry: a.images_) {//mapping vertices of #a to new ones
-    slp::map_vertices(root_entry.second, &new_vertices,
-                      std::bind(&EndomorphismSLP<TerminalSymbol>::map_vertex, *this, std::placeholders::_1, std::placeholders::_2));
-  }
-
-  //replacing roots
-  std::map<TerminalSymbol, slp::Vertex> new_images;
-  for (const auto& root_entry: a.images_) {
-    auto new_root = new_vertices.find(root_entry.second)->second;
-    new_images.insert(std::make_pair(root_entry.first, new_root));
-  }
-  //adding images that were not inserted
-  for (const auto& root_entry: images_) {
-    if (new_images.find(root_entry.first) == new_images.end())//it was not mapped by a
-      new_images.insert(root_entry);
-  }
-
-  swap(images_, new_images);
-  return *this;
-}
-
-template<typename TerminalSymbol>
-slp::Vertex EndomorphismSLP<TerminalSymbol>::map_vertex(const slp::Vertex& vertex, const std::unordered_map<slp::Vertex, slp::Vertex>& images) const {
-  auto item = images.find(vertex.negate());
-  if (item != images.end()) {//already mapped inverse
-    return item->second.negate();
-  }
-
-  if (!vertex)
-    return vertex;//Mapping null vertex
-
-  if (vertex.height() == 1) {//the vertex is terminal so map it to our corresponding root
-    TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
-    bool is_positive = is_positive_terminal_symbol(symbol);
-    TerminalSymbol positive_symbol = is_positive ? symbol : -symbol;
-    slp::Vertex v = image(positive_symbol);
-    if (TerminalVertex(positive_symbol) == v)//if id map
-      return vertex;
-    return is_positive ? v : v.negate();
-  } else {//for a nonterminal we already processed its children because postorder inspector
-    auto left_val = images.find(vertex.left_child());
-    auto right_val = images.find(vertex.right_child());
-    assert(left_val != images.end() && right_val != images.end());
-    const slp::Vertex& left = left_val->second;
-    const slp::Vertex& right = right_val->second;
-    if (left == vertex.left_child() && right == vertex.right_child()) //if children were not copied, then we should not copy vertex
-      return vertex;
-    return slp::NonterminalVertex(left, right);
-  }
-}
-
-template<typename TerminalSymbol>
-void EndomorphismSLP<TerminalSymbol>::save_to(std::ostream* out) const {
-  long vertex_num = 0;
-
-  std::unordered_map<size_t, std::pair<long, long>> non_terminals;
-  std::unordered_map<size_t, TerminalSymbol> terminals;
-
-  //we save the order in wich vertices occur during postorder inspection because we want to save them in this
-  //order so it would be easier to reconstruct the automorphism later
-  std::vector<long> non_terminals_order;
-  std::vector<long> terminals_order;
-
-  auto processor = [&] (const slp::Vertex& vertex, std::unordered_map<slp::Vertex, long>& mapped_images) {
-    auto item = mapped_images.find(vertex.negate());
-    if (item != mapped_images.end()) {//inverse was already visited
-      return -item->second; //negate_index
-    }
-
-    ++vertex_num;
-    if (vertex.height() == 1) {//the vertex is terminal
-      TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
-      bool is_positive = symbol > 0;
-      const TerminalSymbol positive_symbol = is_positive ? symbol : - symbol;
-      terminals.insert(std::make_pair(vertex_num, positive_symbol));
-      terminals_order.push_back(vertex_num);
-      if (is_positive) {
-        mapped_images.insert(std::make_pair(vertex.negate(), -vertex_num));
-        return vertex_num;
-      } else {
-        mapped_images.insert(std::make_pair(vertex.negate(), vertex_num));
-        return -vertex_num;
-      }
-    } else {//nonterminal
-      size_t left_val = mapped_images.find(vertex.left_child())->second;
-      size_t right_val = mapped_images.find(vertex.right_child())->second;
-      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
-      non_terminals_order.push_back(vertex_num);
-    }
-    return vertex_num;
-  };
-
-  std::unordered_map<slp::Vertex, long> vertex_numbers;
-  for (const auto& root_entry: images_) {
-    slp::map_vertices(root_entry.second, &vertex_numbers,
-                      processor);
-  }
-
-  //writing
-  //"number of nontrivial images" "number of terminals" "number of non-terminals"
-  *out << images_.size() << " " << terminals.size() << " " << non_terminals.size() << std::endl;
-
-  //writing terminal symbols
-  //"terminal vertex index" "terminal symbol"
-  for (long terminal_vertex_index: terminals_order) {
-    const auto& terminal = *(terminals.find(terminal_vertex_index));
-    *out << terminal.first << " " << terminal.second << std::endl;
-  }
-
-  //writing non-terminals
-  //"vertex index" "left child index" "right child index"
-  for (size_t non_terminal_vertex_index: non_terminals_order) {
-    const auto& non_terminal = *(non_terminals.find(non_terminal_vertex_index));
-    *out << non_terminal.first << " " << non_terminal.second.first << " " << non_terminal.second.second << std::endl;
-  }
-
-  //writing roots
-  //"terminal symbol" "vertex index"
-  for (const auto& root_entry: images_)
-    *out << root_entry.first << " " << vertex_numbers.find(root_entry.second)->second << std::endl;
-}
-
-template<typename TerminalSymbol>
-EndomorphismSLP<TerminalSymbol> EndomorphismSLP<TerminalSymbol>::load_from(std::istream* in) {
-  size_t roots_num;
-  size_t terminals_num;
-  size_t non_terminals_num;
-  *in >> roots_num >> terminals_num >> non_terminals_num;
-
-  std::unordered_map<long, slp::Vertex> vertices;
-  for (int i = 0; i < terminals_num; ++i) {
-    long index;
-    TerminalSymbol image;
-    *in >> index >> image;
-    in->ignore();
-    vertices.insert(std::make_pair(index, TerminalVertex(image)));
-  }
-
-  auto get_vertex = [&vertices] (long index) {
-    bool is_positive = index > 0;
-    long positive_index = is_positive ? index : -index;
-    const slp::Vertex& v = vertices.find(positive_index)->second;
-    return is_positive ? v : v.negate();
-  };
-
-  for (int i = 0; i < non_terminals_num; ++i) {
-    long index;
-    long l_index;
-    long r_index;
-    *in >> index >> l_index >> r_index;
-    in->ignore();
-    const slp::Vertex& left = get_vertex(l_index);
-    const slp::Vertex& right = get_vertex(r_index);
-    vertices.insert(std::make_pair(index, slp::NonterminalVertex(left, right)));
-  }
-
-  EndomorphismSLP e;
-  for (int i = 0; i < roots_num; ++i) {
-    TerminalSymbol key;
-    size_t index;
-    *in >> key >> index;
-    in->ignore();
-    const slp::Vertex& root = get_vertex(index);
-    e.images_.insert(std::make_pair(key, root));
-  }
-  return e;
-}
-
-
-template<typename TerminalSymbol>
-void EndomorphismSLP<TerminalSymbol>::save_graphviz(std::ostream *p_out, const std::string& name) const {
-  static const char* INDENT = "\t";
-
-  std::ostream& out = *p_out;
-  out << "digraph " << name << " {" << std::endl;
-  out << "node [shape=point]" << std::endl;
-
-  long vertex_num = 0;
-
-  std::unordered_map<size_t, std::pair<long, long>> non_terminals;
-  std::unordered_map<size_t, TerminalSymbol> terminals;
-  std::unordered_map<TerminalSymbol, size_t> sym_to_vertex_num;
-
-  auto processor = [&] (const slp::Vertex& vertex, std::unordered_map<slp::Vertex, long>& mapped_images) {
-    auto item = mapped_images.find(vertex.negate());
-    if (item != mapped_images.end()) {//inverse was already visited
-      auto negate_index = item->second;
-      return -negate_index;
-    }
-
-    ++vertex_num;
-    if (vertex.height() == 1) {//the vertex is terminal
-      TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
-      bool is_positive = symbol > 0;
-      const TerminalSymbol positive_symbol = is_positive ? symbol : - symbol;
-      terminals.insert(std::make_pair(vertex_num, positive_symbol));
-      sym_to_vertex_num.insert(std::make_pair(positive_symbol, vertex_num));
-      if (is_positive) {
-        mapped_images.insert(std::make_pair(vertex.negate(), -vertex_num));
-        return vertex_num;
-      } else {
-        mapped_images.insert(std::make_pair(vertex.negate(), vertex_num));
-        return -vertex_num;
-      }
-    } else {//nonterminal
-      size_t left_val = mapped_images.find(vertex.left_child())->second;
-      size_t right_val = mapped_images.find(vertex.right_child())->second;
-      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
-    }
-    return vertex_num;
-  };
-
-  std::unordered_map<slp::Vertex, long> vertex_numbers;
-  for (const auto& root_entry: images_) {
-    slp::map_vertices(root_entry.second, &vertex_numbers,
-                      processor);
-  }
-
-  //writing root styles
-  for (const auto& root_entry: images_) {
-    out << INDENT << "\"i" << root_entry.first << "\" [shape=plaintext, label=\"" << root_entry.first << "\"];" << std::endl;
-
-    out << INDENT << "\"i" << root_entry.first << "\" -> ";
-    const slp::Vertex& img = root_entry.second;
-    if (img.height() <= 1) {
-      TerminalSymbol symbol = TerminalVertex(img).terminal_symbol();
-      bool is_positive = symbol > 0;
-      TerminalSymbol positive_symbol = is_positive ? symbol : -symbol;
-      const auto& terminal = sym_to_vertex_num.find(positive_symbol);
-      if (terminal != sym_to_vertex_num.end()) {
-        if (is_positive) {
-          out << terminal->second << ";" << std::endl;
-        } else {
-          out << terminal->second << "[label=\"-\"];" << std::endl;
-        }
-      } else {
-        out << "\"" << symbol << "\"[shape=plaintext];" << std::endl;
-      }
-    } else {
-      auto non_terminal_index = vertex_numbers.find(img)->second;
-      if (non_terminal_index > 0) {
-        out << non_terminal_index << " [style=dotted];" << std::endl;
-      } else {
-        out << (-non_terminal_index) << " [style=dotted, label=\"-\"];" << std::endl;
-      }
-    }
-  }
-
-  //writing terminals style
-  for (const auto& pair: terminals) {
-    out << INDENT << pair.first << " [shape=plaintext, label=\"" << pair.second << "\"];" << std::endl;
-  }
-
-  //writing non-terminals
-  for (const auto& non_terminal: non_terminals) {
-    size_t non_terminal_index = non_terminal.first;
-
-    auto left_index = non_terminal.second.first;
-    auto right_index = non_terminal.second.second;
-    if (left_index > 0) {
-      out << INDENT << non_terminal_index << " -> " << left_index << ";" << std::endl;
-    } else {
-      out << INDENT << non_terminal_index << " -> " << -left_index << "[label=\"-\"];" << std::endl;
-    }
-    if (right_index > 0){
-      out << INDENT << non_terminal_index << " -> " << right_index << "[color=red,style=dashed];" << std::endl;
-    } else {
-      out << INDENT << non_terminal_index << " -> " << -right_index << "[color=red,style=dashed,label=\"-\"];" << std::endl;
-    }
-  }
-
-
-  out << "}" << std::endl;
-}
-
-template<typename TerminalSymbol>
-void EndomorphismSLP<TerminalSymbol>::print(std::ostream *p_out) const {
-  std::ostream& out = *p_out;
-
-  size_t vertex_num = 0;
-
-  std::unordered_map<size_t, std::pair<size_t, size_t>> non_terminals;
-  std::unordered_map<size_t, TerminalSymbol> terminals;
-
-  auto processor = [&] (const slp::Vertex& vertex, const std::unordered_map<slp::Vertex, size_t>& mapped_images) {
-    ++vertex_num;
-    if (vertex.height() == 1) {//the vertex is terminal
-      const TerminalSymbol& symbol = TerminalVertex(vertex).terminal_symbol();
-      terminals.insert(std::make_pair(vertex_num, symbol));
-    } else {//nonterminal
-      size_t left_val = mapped_images.find(vertex.left_child())->second;
-      size_t right_val = mapped_images.find(vertex.right_child())->second;
-      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
-    }
-    return vertex_num;
-  };
-
-  std::unordered_map<slp::Vertex, size_t> vertex_numbers;
-  for (auto root_entry: images_) {
-    slp::map_vertices(root_entry.second, &vertex_numbers,
-                      processor);
-  }
-
-  std::unordered_map<size_t, TerminalSymbol> non_terminals_to_roots;
-
-  //writing root styles
-  for (auto root_entry: images_) {
-    auto img = root_entry.second;
-    if (img.height() <= 1) {
-      auto symbol = TerminalVertex(img).terminal_symbol();
-      out << "\"" << root_entry.first << "\" -> \"" << symbol << "\"" << std::endl;
-    } else {
-      non_terminals_to_roots.insert(std::make_pair(vertex_numbers.find(img)->second, root_entry.first));
-    }
-  }
-
-  //writing non-terminals
-  for (auto non_terminal: non_terminals) {
-    size_t non_terminal_index = non_terminal.first;
-
-    size_t left_index = non_terminal.second.first;
-    size_t right_index = non_terminal.second.second;
-    auto left_terminal = terminals.find(left_index);
-    auto right_terminal = terminals.find(right_index);
-
-    auto root_symbol = non_terminals_to_roots.find(non_terminal_index);
-    if (root_symbol == non_terminals_to_roots.end()) {
-      out << non_terminal_index;
-    } else {
-      out << "\"" << root_symbol->second << "\"";
-    }
-
-    out << " -> ";
-    if (left_terminal == terminals.end()) {
-      out << left_index;
-    } else {
-      out << "\"" << left_terminal->second << "\"";
-    }
-    out << " ";
-    if (right_terminal == terminals.end()) {
-      out << right_index;
-    } else {
-      out << "\"" << right_terminal->second << "\"";
-    }
-    out << std::endl;
-  }
-}
-
-
-namespace internal {
-  class Packer {//todo remove class
-    public:
-      static slp::Vertex pack_slps_into_one(const std::vector<slp::Vertex>& v) {
-        std::size_t num = v.size();
-        assert (num > 0);
-        if (num == 1) {
-          return v[0];
-        }
-        std::vector<slp::Vertex> packed_v;
-        unsigned int packed_num = (num / 2) + (num % 2);
-        packed_v.reserve(packed_num);
-        for (std::size_t i = 0; i < num - 1; i += 2) {
-          packed_v.push_back(slp::NonterminalVertex(v[i], v[i + 1]));
-        }
-        if (num % 2 == 1) {
-          packed_v.push_back(v.back());
-        }
-        return pack_slps_into_one(packed_v);
-      }
-  };
-}
-
-template <typename TerminalSymbol>
-EndomorphismSLP<TerminalSymbol> EndomorphismSLP<TerminalSymbol>::normal_form() const {
-  if (non_trivial_images_num() == 0)
-    return EndomorphismSLP();
-  //we rewrite all vertices into a single SLP then find normal form
-  //and then split into pieces according to original vertices lengths
-
-  //end positions in the unifying SLP
-  std::vector<std::pair<TerminalSymbol, LongInteger> > end_positions;
-
-  //vertices to combine into SLP
-  std::vector<slp::Vertex> vertices;
-  vertices.reserve(non_trivial_images_num());
-
-  LongInteger length_accumulator(0);
-  for_each_non_trivial_image([&] (const symbol_image_pair_type& pair) {
-    const TerminalSymbol& k = pair.first;
-    const slp::Vertex& v = pair.second;
-
-    //fill positions
-    length_accumulator += v.length();
-    end_positions.push_back(std::make_pair(k, length_accumulator));
-
-    //adding vertices to process
-    vertices.push_back(v);
-  });
-
-  slp::Vertex slp = internal::Packer::pack_slps_into_one(vertices);
-  auto nf = slp::recompression::normal_form(slp);
-
-  //extracting slps
-  EndomorphismSLP result;
-  LongInteger begin(0);
-  for (auto key_pos_pair: end_positions) {
-    auto end = key_pos_pair.second;
-    auto sub_slp = slp::get_sub_slp(nf, begin, end);
-    result.images_.insert(std::make_pair(key_pos_pair.first, sub_slp));
-    begin = end;
-  }
-
-  return result;
-}
-
-//-------------------------------------------------------------------------
-// Implementation of helper functions.
-
-
-template<typename TerminalSymbol>
-unsigned int height(const EndomorphismSLP<TerminalSymbol>& e) {
-  unsigned int h = 0;
-  auto pick_max_height = [&h] (const typename EndomorphismSLP<TerminalSymbol>::symbol_image_pair_type& v) {
-    const unsigned int v_h = v.second.height();
-    if (v_h > h)
-      h = v_h;
-  };
-  e.for_each_non_trivial_image(pick_max_height);
-  return h;
-}
-
-
-template<typename TerminalSymbol>
-unsigned int slp_vertices_num(const EndomorphismSLP<TerminalSymbol>& e) {
-  std::unordered_set<slp::Vertex> visited_vertices;
-
-  auto acceptor = [&visited_vertices] (const slp::inspector::InspectorTask& task) {
-    return visited_vertices.count(task.vertex) == 0
-        && visited_vertices.count(task.vertex.negate()) == 0;
-  };
-
-  auto inspect_root =[&acceptor,&visited_vertices] (const typename EndomorphismSLP<TerminalSymbol>::symbol_image_pair_type& v) {
-    slp::Inspector<slp::inspector::Postorder, decltype(acceptor)> inspector(v.second, acceptor);
-    while (!inspector.stopped()) {
-      visited_vertices.insert(inspector.vertex());
-      inspector.next();
-    }
-  };
-
-  e.for_each_non_trivial_image(inspect_root);
-  return visited_vertices.size();
-}
-
-template<typename TerminalSymbol>
-unsigned int slp_unique_images_length_num(const EndomorphismSLP<TerminalSymbol>& e) {
-  std::set<LongInteger> visited_vertices;//map sum images length -> vertex
-
-  auto acceptor = [&visited_vertices] (const slp::inspector::InspectorTask& task) {
-    return visited_vertices.find(task.vertex.length()) == visited_vertices.end();
-  };
-
-  auto inspect_root =[&acceptor,&visited_vertices] (const typename EndomorphismSLP<TerminalSymbol>::symbol_image_pair_type& v) {
-    slp::Inspector<slp::inspector::Postorder, decltype(acceptor)> inspector(v.second, acceptor);
-    while (!inspector.stopped()) {
-      visited_vertices.insert(inspector.vertex().length());
-      inspector.next();
-    }
-  };
-
-  e.for_each_non_trivial_image(inspect_root);
-  return visited_vertices.size();
-}
-
-
-template<typename TerminalSymbol>
-std::map<TerminalSymbol, LongInteger> images_length(const EndomorphismSLP<TerminalSymbol>& e) {
-  std::map<TerminalSymbol, LongInteger> key_to_lengths;
-  auto add_length = [&key_to_lengths] (const typename EndomorphismSLP<TerminalSymbol>::symbol_image_pair_type& pair) {
-   auto key = pair.first;
-   slp::Vertex v = pair.second;
-   key_to_lengths.insert(std::make_pair(key, v.length()));
-  };
-  e.for_each_non_trivial_image(add_length);
-  return key_to_lengths;
-}
 
 } /* namespace crag */
 #endif /* CRAG_FREE_GROUPS_ENDOMORPHISM_SLP_H_ */

--- a/FreeGroup/include/FGACrypto.h
+++ b/FreeGroup/include/FGACrypto.h
@@ -40,7 +40,7 @@ namespace fga_crypto {
       const unsigned int C_SIZE = 50;
   };
 
-  typedef EndomorphismSLP<int> Aut;
+  typedef EndomorphismSLP Aut;
   typedef AutomorphismDescription<Aut> AutDescription;
   typedef CommutatorSet<AutDescription> CommSet;
 
@@ -148,9 +148,9 @@ namespace fga_crypto {
           shared_key_() {
 
         //generating alphas, betas
-        UniformAutomorphismSLPGenerator<int, RandomEngine> random_for_alphas(params.N, &rand);
-        UniformAutomorphismSLPGenerator<int, RandomEngine> random_for_betas(params.N + 1, 2 * params.N, &rand);
-        UniformAutomorphismSLPGenerator<int, RandomEngine> random_for_c(2 * params.N, &rand);
+        UniformAutomorphismSLPGenerator<RandomEngine> random_for_alphas(params.N, &rand);
+        UniformAutomorphismSLPGenerator<RandomEngine> random_for_betas(params.N + 1, 2 * params.N, &rand);
+        UniformAutomorphismSLPGenerator<RandomEngine> random_for_c(2 * params.N, &rand);
 
         alphas_.reserve(4);
         betas_.reserve(4);

--- a/FreeGroup/include/slp_vertex.h
+++ b/FreeGroup/include/slp_vertex.h
@@ -21,6 +21,9 @@ typedef mpz_class LongInteger;
 namespace crag {
 namespace slp {
 
+//! Type of the basic character
+typedef int64_t TerminalSymbol;
+
 namespace internal {
 class BasicVertex;
 struct BasicVertexAllocatorTag{};
@@ -190,21 +193,19 @@ inline void Vertex::debug_print(::std::ostream* out) const {
   }
 }
 
-
 //! Terminal vertex in a SLP. Produces word of length 1.
-template <typename TerminalSymbol>
-class TerminalVertexTemplate : public Vertex {
+class TerminalVertex : public Vertex {
   public:
-    TerminalVertexTemplate() = delete;
+    TerminalVertex() = delete;
 
-    explicit TerminalVertexTemplate(TerminalSymbol terminal_symbol)
+    explicit TerminalVertex(TerminalSymbol terminal_symbol)
       : Vertex(static_cast<typename Vertex::VertexSignedId>(terminal_symbol), nullptr)
       , terminal_symbol_(terminal_symbol)
     {
       assert(height() == 1 && length() == 1);
     }
 
-    explicit TerminalVertexTemplate(const Vertex& vertex)
+    explicit TerminalVertex(const Vertex& vertex)
       : Vertex(vertex)
       , terminal_symbol_()
     {
@@ -229,8 +230,7 @@ class TerminalVertexTemplate : public Vertex {
     TerminalSymbol terminal_symbol_;
 };
 
-template <typename TerminalSymbol>
-::std::ostream& operator << (::std::ostream& stream, const TerminalVertexTemplate<TerminalSymbol>& vertex) {
+inline ::std::ostream& operator << (::std::ostream& stream, const TerminalVertex& vertex) {
   return stream << vertex.terminal_symbol();
 }
 

--- a/FreeGroup/include/slp_vertex_word.h
+++ b/FreeGroup/include/slp_vertex_word.h
@@ -106,7 +106,6 @@ class TerminalVertexInspector : public Inspector<TerminalVertexPath, AcceptFunct
  * in all standard algorithms this distance can not be achieved, because it takes too long to move
  * this iterator so far.
  */
-template <typename TerminalSymbol>
 class VertexWordIterator : public std::iterator <
         std::forward_iterator_tag,      //iterator_category
         const TerminalSymbol            //value_type
@@ -127,14 +126,14 @@ class VertexWordIterator : public std::iterator <
     explicit VertexWordIterator(const Vertex& root)
       : inspector_(root)
       , root_(&root)
-      , current_symbol_(TerminalVertexTemplate<TerminalSymbol>(inspector_.vertex()).terminal_symbol())
+      , current_symbol_(TerminalVertex(inspector_.vertex()).terminal_symbol())
     { }
 
     //use default copy/move constructors/assignments
 
     VertexWordIterator& operator++() {   //!< Preincrement
       ++inspector_;
-      current_symbol_ = TerminalVertexTemplate<TerminalSymbol>(inspector_.vertex()).terminal_symbol();
+      current_symbol_ = TerminalVertex(inspector_.vertex()).terminal_symbol();
       return *this;
     }
 
@@ -154,7 +153,7 @@ class VertexWordIterator : public std::iterator <
 
     VertexWordIterator& operator+=(const LongInteger& shift) {
       inspector_.go_to_position(shift);
-      current_symbol_ = TerminalVertexTemplate<TerminalSymbol>(inspector_.vertex()).terminal_symbol();
+      current_symbol_ = TerminalVertex(inspector_.vertex()).terminal_symbol();
       return *this;
     }
 
@@ -182,11 +181,10 @@ class VertexWordIterator : public std::iterator <
 };
 
 //! Word produced by some #slp::Vertex
-template <typename TerminalSymbol>
 class VertexWord {
   public:
     typedef TerminalSymbol value_type;
-    typedef VertexWordIterator<TerminalSymbol> const_iterator; //no iterator, only const
+    typedef VertexWordIterator const_iterator; //no iterator, only const
     typedef const TerminalSymbol& const_reference;
     //we do not define size_type, because size() should return LongInteger, which is not integral
 
@@ -218,7 +216,7 @@ class VertexWord {
       return static_cast<bool>(matching_table->matches(root_, other.root_));
     }
 
-    TerminalSymbol operator[](LongInteger index) const; //!< Get one letter from the word
+    inline TerminalSymbol operator[](LongInteger index) const; //!< Get one letter from the word
 
     const_iterator begin() const { //!< Get the iterator to the first symbol
       return const_iterator(root_);
@@ -240,8 +238,7 @@ class VertexWord {
     Vertex root_; //!< The root vertex producing this word
 };
 
-template <typename TerminalSymbol>
-::std::ostream& operator<<(::std::ostream& out, const VertexWord<TerminalSymbol>& word) {
+inline ::std::ostream& operator<<(::std::ostream& out, const VertexWord& word) {
   for(auto symbol : word) {
     out << symbol;
   }
@@ -249,8 +246,7 @@ template <typename TerminalSymbol>
   return out;
 }
 
-template <typename TerminalSymbol>
-TerminalSymbol VertexWord<TerminalSymbol>::operator[](LongInteger index) const {
+inline TerminalSymbol VertexWord::operator[](LongInteger index) const {
   Vertex current_vertex = root_;
 
   while (current_vertex.height() > 1) {
@@ -262,7 +258,7 @@ TerminalSymbol VertexWord<TerminalSymbol>::operator[](LongInteger index) const {
     }
   }
 
-  return TerminalVertexTemplate<TerminalSymbol>(current_vertex).terminal_symbol();
+  return TerminalVertex(current_vertex).terminal_symbol();
 }
 
 } // namespace slp

--- a/FreeGroup/main/cache_length_expirement.cpp
+++ b/FreeGroup/main/cache_length_expirement.cpp
@@ -23,8 +23,7 @@
 using crag::slp::Vertex;
 using crag::slp::VertexWord;
 using crag::slp::PreorderInspector;
-using crag::slp::TerminalVertexTemplate;
-typedef crag::slp::TerminalVertexTemplate<int> TerminalVertex;
+using crag::slp::TerminalVertex;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 using crag::UniformAutomorphismSLPGenerator;
@@ -225,8 +224,8 @@ int main() {
   size_t endomorphisms_number = 10;
   while (endomorphisms_number < 10000) {
     for (auto rank : {3, 6, 10, 20, 40, 100}) {
-      UniformAutomorphismSLPGenerator<int> generator(rank, seed + endomorphisms_number + rank);
-      auto slp = EndomorphismSLP<int>::composition(endomorphisms_number, generator).image(1);
+      UniformAutomorphismSLPGenerator<> generator(rank, seed + endomorphisms_number + rank);
+      auto slp = EndomorphismSLP::composition(endomorphisms_number, generator).image(1);
       max_distance = 0;
 
       std::unordered_map<Vertex, Vertex> reduced_vertices;

--- a/FreeGroup/main/hash_reduce.cpp
+++ b/FreeGroup/main/hash_reduce.cpp
@@ -23,8 +23,7 @@
 using crag::slp::Vertex;
 using crag::slp::VertexWord;
 using crag::slp::PreorderInspector;
-using crag::slp::TerminalVertexTemplate;
-typedef crag::slp::TerminalVertexTemplate<int> TerminalVertex;
+using crag::slp::TerminalVertex;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 using crag::UniformAutomorphismSLPGenerator;
@@ -65,7 +64,7 @@ int main() {
   constexpr size_t RANK = 6;
   constexpr size_t ENDOMORPHISMS_NUMBER = 2200;
   size_t seed = 112233;
-  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
   auto begin = std::chrono::system_clock::now();
   int count = REPEAT;
 
@@ -87,7 +86,7 @@ int main() {
   size_t reduce_different = 0;
 
   while (--count >= 0) {
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
     crag::slp::MatchingTable matching_table;
     std::unordered_map<Vertex, Vertex> reduced_vertices;
     WeakVertexHashAlgorithms::Cache vertex_hashes;

--- a/FreeGroup/main/profile_matching_new.cpp
+++ b/FreeGroup/main/profile_matching_new.cpp
@@ -20,13 +20,14 @@
 
 using crag::slp::Vertex;
 using crag::slp::PreorderInspector;
-typedef crag::slp::TerminalVertexTemplate<char> TerminalVertex;
+using crag::slp::TerminalVertex;
+using crag::slp::TerminalSymbol;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 
 Vertex get_random_slp_on_2_letters(unsigned int WORD_SIZE) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(TerminalSymbol{} + 1);
+  TerminalVertex b(TerminalSymbol{} + 2);
 
   int random_word = rand() % (1 << WORD_SIZE);
   std::vector<unsigned int> random_word_split;

--- a/FreeGroup/main/profile_normal_form.cpp
+++ b/FreeGroup/main/profile_normal_form.cpp
@@ -23,8 +23,7 @@
 using crag::slp::Vertex;
 using crag::slp::VertexWord;
 using crag::slp::PreorderInspector;
-using crag::slp::TerminalVertexTemplate;
-typedef crag::slp::TerminalVertexTemplate<int> TerminalVertex;
+using crag::slp::TerminalVertex;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 using crag::UniformAutomorphismSLPGenerator;
@@ -36,7 +35,7 @@ int main() {
   constexpr size_t RANK = 6;
   constexpr size_t ENDOMORPHISMS_NUMBER = 2000;
   size_t seed = 112233;
-  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
   auto begin = std::chrono::system_clock::now();
   int count = REPEAT;
 
@@ -48,7 +47,7 @@ int main() {
   auto normal_form_duration = begin - begin;
 
   while (--count >= 0) {
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
 //    std::unordered_map<Vertex, Vertex> reduced_vertices;
 //    VertexHashAlgorithms::Cache vertex_hashes;

--- a/FreeGroup/main/profile_reduce.cpp
+++ b/FreeGroup/main/profile_reduce.cpp
@@ -19,7 +19,7 @@
 
 using crag::slp::Vertex;
 using crag::slp::PreorderInspector;
-typedef crag::slp::TerminalVertexTemplate<int> TerminalVertex;
+using crag::slp::TerminalVertex;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 using crag::UniformAutomorphismSLPGenerator;
@@ -31,11 +31,11 @@ int main() {
   const size_t RANK = 3;
   const size_t ENDOMORPHISMS_NUMBER = 100;
   size_t seed = 112233;
-  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
   auto begin = std::chrono::system_clock::now();
   int count = REPEAT;
   while (--count >= 0) {
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
     Vertex reduced = reduce(image);
     auto end = std::chrono::system_clock::now();

--- a/FreeGroup/main/profile_reduce_narrow.cpp
+++ b/FreeGroup/main/profile_reduce_narrow.cpp
@@ -15,14 +15,14 @@ int main() {
   constexpr size_t RANK = 6;
   constexpr size_t ENDOMORPHISMS_NUMBER = 2200;
   size_t seed = 112233;
-  crag::UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  crag::UniformAutomorphismSLPGenerator<> generator(RANK, seed);
 
   typedef crag::slp::TVertexHashAlgorithms<
       crag::slp::hashers::SinglePowerHash,
       crag::slp::hashers::PermutationHash<crag::Permutation16>
   > VertexHashAlgorithms;
 
-  auto slp = crag::EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+  auto slp = crag::EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
   VertexHashAlgorithms::Cache calculated_hashes;
   std::unordered_map<crag::slp::Vertex, crag::slp::Vertex> reduced_vertices;

--- a/FreeGroup/main/reduce_structure.cpp
+++ b/FreeGroup/main/reduce_structure.cpp
@@ -23,8 +23,7 @@
 using crag::slp::Vertex;
 using crag::slp::VertexWord;
 using crag::slp::PreorderInspector;
-using crag::slp::TerminalVertexTemplate;
-typedef crag::slp::TerminalVertexTemplate<int> TerminalVertex;
+using crag::slp::TerminalVertex;
 using crag::slp::NonterminalVertex;
 using crag::slp::MatchingTable;
 using crag::UniformAutomorphismSLPGenerator;
@@ -257,14 +256,14 @@ int main() {
   constexpr size_t RANK = 6;
   constexpr size_t ENDOMORPHISMS_NUMBER = 2200;
   size_t seed = 112233;
-  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
 
   typedef crag::slp::TVertexHashAlgorithms<
       crag::slp::hashers::SinglePowerHash,
       crag::slp::hashers::PermutationHash<crag::Permutation16>
   > VertexHashAlgorithms;
 
-  auto slp = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+  auto slp = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
   std::unordered_map<Vertex, Vertex> reduced_vertices;
   VertexHashAlgorithms::Cache hash_cache;

--- a/FreeGroup/src/EndomorphismSLP.cpp
+++ b/FreeGroup/src/EndomorphismSLP.cpp
@@ -1,0 +1,565 @@
+/*
+ * \file EndomorphismSLP.cpp
+ *
+ * 
+ */
+
+#include "EndomorphismSLP.h"
+
+namespace crag {
+
+EndomorphismSLP EndomorphismSLP::inverse() const {
+  if (images_.size() == 0) //identity
+    return *this;
+  if (images_.size() > 1)
+    throw std::invalid_argument("Unsupported endomorphism with more than one non-trivial terminal image!");
+
+  auto img = images_.begin();
+  TerminalSymbol symbol = img->first;
+  slp::Vertex image = img->second;
+  if (image.height() > 2)
+    throw std::invalid_argument("Unsupported endomorphism with unsupported slp height > 2!");
+
+  if (image.height() == 1) {//inverter
+    return *this;
+  }
+
+  TerminalVertex left(image.left_child());
+  TerminalVertex right(image.right_child());
+
+  TerminalSymbol left_symbol = left.terminal_symbol();
+  TerminalSymbol right_symbol = right.terminal_symbol();
+
+  if (! (left_symbol == symbol || right_symbol == symbol))
+    throw std::invalid_argument("Unsupported endomorphism not mapping the symbol to the product of another one and itself!");
+
+  if (left_symbol == symbol) {
+    return right_multiplier(symbol, -right_symbol);
+  } else {
+    return left_multiplier(-left_symbol, symbol);
+  }
+}
+
+bool EndomorphismSLP::operator==(const EndomorphismSLP& a) const {
+  if (this == &a)
+    return true;
+  if (non_trivial_images_num() != a.non_trivial_images_num())
+    return false;
+  auto images = non_trivial_images_range();
+  auto a_images = a.non_trivial_images_range();
+
+  //checking that the same letters have non-trivial images
+  auto img_iterator = images_.begin();
+  auto a_img_iterator = a.images_.begin();
+  while (img_iterator != images_.end()) {
+    if (img_iterator->first != a_img_iterator->first)
+      return false;
+    ++img_iterator;
+    ++a_img_iterator;
+  }
+
+  //checking that the images are the same
+  //todo: rewrite this method if it is used
+  slp::MatchingTable mt;
+  img_iterator = images_.begin();
+  a_img_iterator = a.images_.begin();
+  while (img_iterator != images_.end()) {
+    slp::VertexWord word(img_iterator->second);
+    slp::VertexWord a_word(a_img_iterator->second);
+    if (!word.is_equal_to(a_word, &mt))
+      return false;
+    ++img_iterator;
+    ++a_img_iterator;
+  }
+
+  return true;
+}
+
+EndomorphismSLP& EndomorphismSLP::operator*=(const EndomorphismSLP& a) {
+  std::unordered_map<slp::Vertex, slp::Vertex> new_vertices;//a's vertices to new vertices correspondence
+
+  for (const auto& root_entry: a.images_) {//mapping vertices of #a to new ones
+    slp::map_vertices(root_entry.second, &new_vertices,
+                      std::bind(&EndomorphismSLP::map_vertex, *this, std::placeholders::_1, std::placeholders::_2));
+  }
+
+  //replacing roots
+  std::map<TerminalSymbol, slp::Vertex> new_images;
+  for (const auto& root_entry: a.images_) {
+    auto new_root = new_vertices.find(root_entry.second)->second;
+    new_images.insert(std::make_pair(root_entry.first, new_root));
+  }
+  //adding images that were not inserted
+  for (const auto& root_entry: images_) {
+    if (new_images.find(root_entry.first) == new_images.end())//it was not mapped by a
+      new_images.insert(root_entry);
+  }
+
+  swap(images_, new_images);
+  return *this;
+}
+
+EndomorphismSLP EndomorphismSLP::conjugate_with(const AutomorphismDescription<EndomorphismSLP>& conjugator) const {
+  return conjugator() * (*this) * conjugator.inverse();
+}
+
+
+slp::Vertex EndomorphismSLP::map_vertex(const slp::Vertex& vertex, const std::unordered_map<slp::Vertex, slp::Vertex>& images) const {
+  auto item = images.find(vertex.negate());
+  if (item != images.end()) {//already mapped inverse
+    return item->second.negate();
+  }
+
+  if (!vertex)
+    return vertex;//Mapping null vertex
+
+  if (vertex.height() == 1) {//the vertex is terminal so map it to our corresponding root
+    TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
+    bool is_positive = is_positive_terminal_symbol(symbol);
+    TerminalSymbol positive_symbol = is_positive ? symbol : -symbol;
+    slp::Vertex v = image(positive_symbol);
+    if (TerminalVertex(positive_symbol) == v)//if id map
+      return vertex;
+    return is_positive ? v : v.negate();
+  } else {//for a nonterminal we already processed its children because postorder inspector
+    auto left_val = images.find(vertex.left_child());
+    auto right_val = images.find(vertex.right_child());
+    assert(left_val != images.end() && right_val != images.end());
+    const slp::Vertex& left = left_val->second;
+    const slp::Vertex& right = right_val->second;
+    if (left == vertex.left_child() && right == vertex.right_child()) //if children were not copied, then we should not copy vertex
+      return vertex;
+    return slp::NonterminalVertex(left, right);
+  }
+}
+
+void EndomorphismSLP::save_to(std::ostream* out) const {
+  long vertex_num = 0;
+
+  std::unordered_map<size_t, std::pair<long, long>> non_terminals;
+  std::unordered_map<size_t, TerminalSymbol> terminals;
+
+  //we save the order in wich vertices occur during postorder inspection because we want to save them in this
+  //order so it would be easier to reconstruct the automorphism later
+  std::vector<long> non_terminals_order;
+  std::vector<long> terminals_order;
+
+  auto processor = [&] (const slp::Vertex& vertex, std::unordered_map<slp::Vertex, long>& mapped_images) {
+    auto item = mapped_images.find(vertex.negate());
+    if (item != mapped_images.end()) {//inverse was already visited
+      return -item->second; //negate_index
+    }
+
+    ++vertex_num;
+    if (vertex.height() == 1) {//the vertex is terminal
+      TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
+      bool is_positive = symbol > 0;
+      const TerminalSymbol positive_symbol = is_positive ? symbol : - symbol;
+      terminals.insert(std::make_pair(vertex_num, positive_symbol));
+      terminals_order.push_back(vertex_num);
+      if (is_positive) {
+        mapped_images.insert(std::make_pair(vertex.negate(), -vertex_num));
+        return vertex_num;
+      } else {
+        mapped_images.insert(std::make_pair(vertex.negate(), vertex_num));
+        return -vertex_num;
+      }
+    } else {//nonterminal
+      size_t left_val = mapped_images.find(vertex.left_child())->second;
+      size_t right_val = mapped_images.find(vertex.right_child())->second;
+      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
+      non_terminals_order.push_back(vertex_num);
+    }
+    return vertex_num;
+  };
+
+  std::unordered_map<slp::Vertex, long> vertex_numbers;
+  for (const auto& root_entry: images_) {
+    slp::map_vertices(root_entry.second, &vertex_numbers,
+                      processor);
+  }
+
+  //writing
+  //"number of nontrivial images" "number of terminals" "number of non-terminals"
+  *out << images_.size() << " " << terminals.size() << " " << non_terminals.size() << std::endl;
+
+  //writing terminal symbols
+  //"terminal vertex index" "terminal symbol"
+  for (long terminal_vertex_index: terminals_order) {
+    const auto& terminal = *(terminals.find(terminal_vertex_index));
+    *out << terminal.first << " " << terminal.second << std::endl;
+  }
+
+  //writing non-terminals
+  //"vertex index" "left child index" "right child index"
+  for (size_t non_terminal_vertex_index: non_terminals_order) {
+    const auto& non_terminal = *(non_terminals.find(non_terminal_vertex_index));
+    *out << non_terminal.first << " " << non_terminal.second.first << " " << non_terminal.second.second << std::endl;
+  }
+
+  //writing roots
+  //"terminal symbol" "vertex index"
+  for (const auto& root_entry: images_)
+    *out << root_entry.first << " " << vertex_numbers.find(root_entry.second)->second << std::endl;
+}
+
+EndomorphismSLP EndomorphismSLP::load_from(std::istream* in) {
+  size_t roots_num;
+  size_t terminals_num;
+  size_t non_terminals_num;
+  *in >> roots_num >> terminals_num >> non_terminals_num;
+
+  std::unordered_map<long, slp::Vertex> vertices;
+  for (int i = 0; i < terminals_num; ++i) {
+    long index;
+    TerminalSymbol image;
+    *in >> index >> image;
+    in->ignore();
+    vertices.insert(std::make_pair(index, TerminalVertex(image)));
+  }
+
+  auto get_vertex = [&vertices] (long index) {
+    bool is_positive = index > 0;
+    long positive_index = is_positive ? index : -index;
+    const slp::Vertex& v = vertices.find(positive_index)->second;
+    return is_positive ? v : v.negate();
+  };
+
+  for (int i = 0; i < non_terminals_num; ++i) {
+    long index;
+    long l_index;
+    long r_index;
+    *in >> index >> l_index >> r_index;
+    in->ignore();
+    const slp::Vertex& left = get_vertex(l_index);
+    const slp::Vertex& right = get_vertex(r_index);
+    vertices.insert(std::make_pair(index, slp::NonterminalVertex(left, right)));
+  }
+
+  EndomorphismSLP e;
+  for (int i = 0; i < roots_num; ++i) {
+    TerminalSymbol key;
+    size_t index;
+    *in >> key >> index;
+    in->ignore();
+    const slp::Vertex& root = get_vertex(index);
+    e.images_.insert(std::make_pair(key, root));
+  }
+  return e;
+}
+
+
+void EndomorphismSLP::save_graphviz(std::ostream *p_out, const std::string& name) const {
+  static const char* INDENT = "\t";
+
+  std::ostream& out = *p_out;
+  out << "digraph " << name << " {" << std::endl;
+  out << "node [shape=point]" << std::endl;
+
+  long vertex_num = 0;
+
+  std::unordered_map<size_t, std::pair<long, long>> non_terminals;
+  std::unordered_map<size_t, TerminalSymbol> terminals;
+  std::unordered_map<TerminalSymbol, size_t> sym_to_vertex_num;
+
+  auto processor = [&] (const slp::Vertex& vertex, std::unordered_map<slp::Vertex, long>& mapped_images) {
+    auto item = mapped_images.find(vertex.negate());
+    if (item != mapped_images.end()) {//inverse was already visited
+      auto negate_index = item->second;
+      return -negate_index;
+    }
+
+    ++vertex_num;
+    if (vertex.height() == 1) {//the vertex is terminal
+      TerminalSymbol symbol = TerminalVertex(vertex).terminal_symbol();
+      bool is_positive = symbol > 0;
+      const TerminalSymbol positive_symbol = is_positive ? symbol : - symbol;
+      terminals.insert(std::make_pair(vertex_num, positive_symbol));
+      sym_to_vertex_num.insert(std::make_pair(positive_symbol, vertex_num));
+      if (is_positive) {
+        mapped_images.insert(std::make_pair(vertex.negate(), -vertex_num));
+        return vertex_num;
+      } else {
+        mapped_images.insert(std::make_pair(vertex.negate(), vertex_num));
+        return -vertex_num;
+      }
+    } else {//nonterminal
+      size_t left_val = mapped_images.find(vertex.left_child())->second;
+      size_t right_val = mapped_images.find(vertex.right_child())->second;
+      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
+    }
+    return vertex_num;
+  };
+
+  std::unordered_map<slp::Vertex, long> vertex_numbers;
+  for (const auto& root_entry: images_) {
+    slp::map_vertices(root_entry.second, &vertex_numbers,
+                      processor);
+  }
+
+  //writing root styles
+  for (const auto& root_entry: images_) {
+    out << INDENT << "\"i" << root_entry.first << "\" [shape=plaintext, label=\"" << root_entry.first << "\"];" << std::endl;
+
+    out << INDENT << "\"i" << root_entry.first << "\" -> ";
+    const slp::Vertex& img = root_entry.second;
+    if (img.height() <= 1) {
+      TerminalSymbol symbol = TerminalVertex(img).terminal_symbol();
+      bool is_positive = symbol > 0;
+      TerminalSymbol positive_symbol = is_positive ? symbol : -symbol;
+      const auto& terminal = sym_to_vertex_num.find(positive_symbol);
+      if (terminal != sym_to_vertex_num.end()) {
+        if (is_positive) {
+          out << terminal->second << ";" << std::endl;
+        } else {
+          out << terminal->second << "[label=\"-\"];" << std::endl;
+        }
+      } else {
+        out << "\"" << symbol << "\"[shape=plaintext];" << std::endl;
+      }
+    } else {
+      auto non_terminal_index = vertex_numbers.find(img)->second;
+      if (non_terminal_index > 0) {
+        out << non_terminal_index << " [style=dotted];" << std::endl;
+      } else {
+        out << (-non_terminal_index) << " [style=dotted, label=\"-\"];" << std::endl;
+      }
+    }
+  }
+
+  //writing terminals style
+  for (const auto& pair: terminals) {
+    out << INDENT << pair.first << " [shape=plaintext, label=\"" << pair.second << "\"];" << std::endl;
+  }
+
+  //writing non-terminals
+  for (const auto& non_terminal: non_terminals) {
+    size_t non_terminal_index = non_terminal.first;
+
+    auto left_index = non_terminal.second.first;
+    auto right_index = non_terminal.second.second;
+    if (left_index > 0) {
+      out << INDENT << non_terminal_index << " -> " << left_index << ";" << std::endl;
+    } else {
+      out << INDENT << non_terminal_index << " -> " << -left_index << "[label=\"-\"];" << std::endl;
+    }
+    if (right_index > 0){
+      out << INDENT << non_terminal_index << " -> " << right_index << "[color=red,style=dashed];" << std::endl;
+    } else {
+      out << INDENT << non_terminal_index << " -> " << -right_index << "[color=red,style=dashed,label=\"-\"];" << std::endl;
+    }
+  }
+
+
+  out << "}" << std::endl;
+}
+
+void EndomorphismSLP::print(std::ostream *p_out) const {
+  std::ostream& out = *p_out;
+
+  size_t vertex_num = 0;
+
+  std::unordered_map<size_t, std::pair<size_t, size_t>> non_terminals;
+  std::unordered_map<size_t, TerminalSymbol> terminals;
+
+  auto processor = [&] (const slp::Vertex& vertex, const std::unordered_map<slp::Vertex, size_t>& mapped_images) {
+    ++vertex_num;
+    if (vertex.height() == 1) {//the vertex is terminal
+      const TerminalSymbol& symbol = TerminalVertex(vertex).terminal_symbol();
+      terminals.insert(std::make_pair(vertex_num, symbol));
+    } else {//nonterminal
+      size_t left_val = mapped_images.find(vertex.left_child())->second;
+      size_t right_val = mapped_images.find(vertex.right_child())->second;
+      non_terminals.insert(std::make_pair(vertex_num, std::make_pair(left_val, right_val)));
+    }
+    return vertex_num;
+  };
+
+  std::unordered_map<slp::Vertex, size_t> vertex_numbers;
+  for (auto root_entry: images_) {
+    slp::map_vertices(root_entry.second, &vertex_numbers,
+                      processor);
+  }
+
+  std::unordered_map<size_t, TerminalSymbol> non_terminals_to_roots;
+
+  //writing root styles
+  for (auto root_entry: images_) {
+    auto img = root_entry.second;
+    if (img.height() <= 1) {
+      auto symbol = TerminalVertex(img).terminal_symbol();
+      out << "\"" << root_entry.first << "\" -> \"" << symbol << "\"" << std::endl;
+    } else {
+      non_terminals_to_roots.insert(std::make_pair(vertex_numbers.find(img)->second, root_entry.first));
+    }
+  }
+
+  //writing non-terminals
+  for (auto non_terminal: non_terminals) {
+    size_t non_terminal_index = non_terminal.first;
+
+    size_t left_index = non_terminal.second.first;
+    size_t right_index = non_terminal.second.second;
+    auto left_terminal = terminals.find(left_index);
+    auto right_terminal = terminals.find(right_index);
+
+    auto root_symbol = non_terminals_to_roots.find(non_terminal_index);
+    if (root_symbol == non_terminals_to_roots.end()) {
+      out << non_terminal_index;
+    } else {
+      out << "\"" << root_symbol->second << "\"";
+    }
+
+    out << " -> ";
+    if (left_terminal == terminals.end()) {
+      out << left_index;
+    } else {
+      out << "\"" << left_terminal->second << "\"";
+    }
+    out << " ";
+    if (right_terminal == terminals.end()) {
+      out << right_index;
+    } else {
+      out << "\"" << right_terminal->second << "\"";
+    }
+    out << std::endl;
+  }
+}
+
+
+namespace internal {
+  class Packer {//todo remove class
+    public:
+      static slp::Vertex pack_slps_into_one(const std::vector<slp::Vertex>& v) {
+        std::size_t num = v.size();
+        assert (num > 0);
+        if (num == 1) {
+          return v[0];
+        }
+        std::vector<slp::Vertex> packed_v;
+        unsigned int packed_num = (num / 2) + (num % 2);
+        packed_v.reserve(packed_num);
+        for (std::size_t i = 0; i < num - 1; i += 2) {
+          packed_v.push_back(slp::NonterminalVertex(v[i], v[i + 1]));
+        }
+        if (num % 2 == 1) {
+          packed_v.push_back(v.back());
+        }
+        return pack_slps_into_one(packed_v);
+      }
+  };
+}
+
+EndomorphismSLP EndomorphismSLP::normal_form() const {
+  if (non_trivial_images_num() == 0)
+    return EndomorphismSLP();
+  //we rewrite all vertices into a single SLP then find normal form
+  //and then split into pieces according to original vertices lengths
+
+  //end positions in the unifying SLP
+  std::vector<std::pair<slp::TerminalSymbol, LongInteger> > end_positions;
+
+  //vertices to combine into SLP
+  std::vector<slp::Vertex> vertices;
+  vertices.reserve(non_trivial_images_num());
+
+  LongInteger length_accumulator(0);
+  for_each_non_trivial_image([&] (const symbol_image_pair_type& pair) {
+    const TerminalSymbol& k = pair.first;
+    const slp::Vertex& v = pair.second;
+
+    //fill positions
+    length_accumulator += v.length();
+    end_positions.push_back(std::make_pair(k, length_accumulator));
+
+    //adding vertices to process
+    vertices.push_back(v);
+  });
+
+  slp::Vertex slp = internal::Packer::pack_slps_into_one(vertices);
+  auto nf = slp::recompression::normal_form(slp);
+
+  //extracting slps
+  EndomorphismSLP result;
+  LongInteger begin(0);
+  for (auto key_pos_pair: end_positions) {
+    auto end = key_pos_pair.second;
+    auto sub_slp = slp::get_sub_slp(nf, begin, end);
+    result.images_.insert(std::make_pair(key_pos_pair.first, sub_slp));
+    begin = end;
+  }
+
+  return result;
+}
+
+//-------------------------------------------------------------------------
+// Implementation of helper functions.
+
+
+unsigned int height(const EndomorphismSLP& e) {
+  unsigned int h = 0;
+  auto pick_max_height = [&h] (const typename EndomorphismSLP::symbol_image_pair_type& v) {
+    const unsigned int v_h = v.second.height();
+    if (v_h > h)
+      h = v_h;
+  };
+  e.for_each_non_trivial_image(pick_max_height);
+  return h;
+}
+
+
+unsigned int slp_vertices_num(const EndomorphismSLP& e) {
+  std::unordered_set<slp::Vertex> visited_vertices;
+
+  auto acceptor = [&visited_vertices] (const slp::inspector::InspectorTask& task) {
+    return visited_vertices.count(task.vertex) == 0
+        && visited_vertices.count(task.vertex.negate()) == 0;
+  };
+
+  auto inspect_root =[&acceptor,&visited_vertices] (const typename EndomorphismSLP::symbol_image_pair_type& v) {
+    slp::Inspector<slp::inspector::Postorder, decltype(acceptor)> inspector(v.second, acceptor);
+    while (!inspector.stopped()) {
+      visited_vertices.insert(inspector.vertex());
+      inspector.next();
+    }
+  };
+
+  e.for_each_non_trivial_image(inspect_root);
+  return visited_vertices.size();
+}
+
+unsigned int slp_unique_images_length_num(const EndomorphismSLP& e) {
+  std::set<LongInteger> visited_vertices;//map sum images length -> vertex
+
+  auto acceptor = [&visited_vertices] (const slp::inspector::InspectorTask& task) {
+    return visited_vertices.find(task.vertex.length()) == visited_vertices.end();
+  };
+
+  auto inspect_root =[&acceptor,&visited_vertices] (const typename EndomorphismSLP::symbol_image_pair_type& v) {
+    slp::Inspector<slp::inspector::Postorder, decltype(acceptor)> inspector(v.second, acceptor);
+    while (!inspector.stopped()) {
+      visited_vertices.insert(inspector.vertex().length());
+      inspector.next();
+    }
+  };
+
+  e.for_each_non_trivial_image(inspect_root);
+  return visited_vertices.size();
+}
+
+
+std::map<slp::TerminalSymbol, LongInteger> images_length(const EndomorphismSLP& e) {
+  std::map<slp::TerminalSymbol, LongInteger> key_to_lengths;
+  auto add_length = [&key_to_lengths] (const typename EndomorphismSLP::symbol_image_pair_type& pair) {
+   auto key = pair.first;
+   slp::Vertex v = pair.second;
+   key_to_lengths.insert(std::make_pair(key, v.length()));
+  };
+  e.for_each_non_trivial_image(add_length);
+  return key_to_lengths;
+}
+
+
+}  // namespace crag
+
+

--- a/FreeGroup/test/EndomorphismSLP_test.cpp
+++ b/FreeGroup/test/EndomorphismSLP_test.cpp
@@ -6,16 +6,14 @@
  */
 
 #include "gtest/gtest.h"
-#include "../include/EndomorphismSLP.h"
+#include "EndomorphismSLP.h"
 
 namespace crag {
-
-typedef typename slp::TerminalVertexTemplate<int> TVertex;
 
 //Auxiliary functions
 
 //! Compares two endomorphisms by comparing images as strings -- very inefficient
-  bool compare_endomorphisms_directly(const EndomorphismSLP<int>& e1, const EndomorphismSLP<int>& e2) {
+  bool compare_endomorphisms_directly(const EndomorphismSLP& e1, const EndomorphismSLP& e2) {
     if (&e1 == &e2)
         return true;
     const int max = e1.max_non_trivial_image_symbol();
@@ -38,7 +36,7 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
 
 
   //! Return string representation of vertex
-  std::string to_string(const slp::VertexWord<int>& word) {
+  std::string to_string(const slp::VertexWord& word) {
     std::stringstream out;
     for (auto wi = word.begin(); wi != word.end(); ++wi) {
       out << *wi;
@@ -47,7 +45,7 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
   }
 
   //! Prints images of terminal symbols
-  std::ostream& operator<<(std::ostream& out, const EndomorphismSLP<int>& e) {
+  std::ostream& operator<<(std::ostream& out, const EndomorphismSLP& e) {
     const int max = e.max_non_trivial_image_symbol();
     out << "[max non trivial symbol=" << max;
     for (int ts = 1; ts <= max; ++ts)
@@ -57,10 +55,10 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
 
 
   //! Finds images of terminal symbols under the composition of given morphisms. Each of the morphisms is either inverter, or left or right multiplier
-  std::vector<std::string> find_image(const std::vector<EndomorphismSLP<int>>& morphisms) {
+  std::vector<std::string> find_image(const std::vector<EndomorphismSLP>& morphisms) {
     unsigned int rank = 0;
     for (auto morph: morphisms) {
-      const EndomorphismSLP<int>::size_type r = morph.max_non_trivial_image_symbol();
+      const EndomorphismSLP::size_type r = morph.max_non_trivial_image_symbol();
       if (r > rank)
         rank = r;
     }
@@ -82,7 +80,7 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
 
         if (v.height() == 1) {//inverter or id
           const vector<int>& img = images[terminal - 1];
-          const int terminal_symbol = TVertex(v).terminal_symbol();
+          const int terminal_symbol = slp::TerminalVertex(v).terminal_symbol();
           if (terminal_symbol == terminal) {//id
             tmp.push_back(img);
           } else {//inverter
@@ -95,8 +93,8 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
             tmp.push_back(tmp_img);
           }
         } else {//righ_or left multiplier
-          const int left_terminal_symbol = TVertex(v.left_child()).terminal_symbol();
-          const int right_terminal_symbol = TVertex(v.right_child()).terminal_symbol();
+          const int left_terminal_symbol = slp::TerminalVertex(v.left_child()).terminal_symbol();
+          const int right_terminal_symbol = slp::TerminalVertex(v.right_child()).terminal_symbol();
           assert(left_terminal_symbol > 0 && right_terminal_symbol > 0);
 
           vector<int> l_img = left_terminal_symbol <= rank ? images[left_terminal_symbol - 1] : vector<int>({left_terminal_symbol});
@@ -127,7 +125,7 @@ typedef typename slp::TerminalVertexTemplate<int> TVertex;
 
 class EndomorphismSLPTest : public ::testing::Test {
     protected:
-  typedef EndomorphismSLP<int> EMorphism;
+  typedef EndomorphismSLP EMorphism;
 
   class CachedProducer {
   public:
@@ -292,7 +290,7 @@ TEST_F(EndomorphismSLPTest, DirectImageCalculationTest) {
 }
 
 TEST_F(EndomorphismSLPTest, NonTrivialImagesNumTest) {
-  EXPECT_EQ(0, EndomorphismSLP<int>::identity().non_trivial_images_num());
+  EXPECT_EQ(0, EndomorphismSLP::identity().non_trivial_images_num());
   for (int i = 1; i < 10; ++i) {
     EXPECT_EQ(1, EMorphism::inverter(i).non_trivial_images_num());
   }
@@ -343,10 +341,10 @@ TEST_F(EndomorphismSLPTest, RangeTest) {
 }
 
 TEST_F(EndomorphismSLPTest, RandomGeneratorConstructorsTest) {
-  UniformAutomorphismSLPGenerator<int> rnd(5);//default
-  UniformAutomorphismSLPGenerator<int> rnd1(10, 546457);//with seed
+  UniformAutomorphismSLPGenerator<> rnd(5);//default
+  UniformAutomorphismSLPGenerator<> rnd1(10, 546457);//with seed
   std::default_random_engine r_engine;
-  UniformAutomorphismSLPGenerator<int> rnd2(4, &r_engine);//with generator
+  UniformAutomorphismSLPGenerator<> rnd2(4, &r_engine);//with generator
   for (int i = 0; i < 100; ++i) {
     EXPECT_EQ(1, rnd().non_trivial_images_num());
     EXPECT_EQ(1, rnd1().non_trivial_images_num());
@@ -356,7 +354,7 @@ TEST_F(EndomorphismSLPTest, RandomGeneratorConstructorsTest) {
 
 TEST_F(EndomorphismSLPTest, RandomGeneratorStressTest) {
   for (auto rank : {1, 5, 10, 20, 30}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10, 30, 60}) {
       std::vector<EMorphism> morphisms;
       for (int i = 0; i < size; ++i)
@@ -375,7 +373,7 @@ TEST_F(EndomorphismSLPTest, RandomGeneratorStressTest) {
 
 TEST_F(EndomorphismSLPTest, ProducerVsIteratorGenerationEquality) {
   for (auto rank : {1, 5, 10, 20, 30}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10, 30, 60}) {
       std::vector<EMorphism> morphisms;
       for (int i = 0; i < size; ++i)
@@ -401,7 +399,7 @@ TEST_F(EndomorphismSLPTest, HeightCalculationTest) {
   EXPECT_EQ(e.image(2).height(), height(EMorphism::left_multiplier(1, 2)));
 
   for (auto rank : {1, 5, 10, 20, 30}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10, 30, 60}) {
       auto e = EMorphism::composition(size, rnd);
       int height = 0;
@@ -486,7 +484,7 @@ TEST_F(EndomorphismSLPTest, SimpleAutomorphismsInvertionTest) {
       }
 
   for (auto rank : {1, 5, 10, 20, 30}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10}) {
       std::vector<EMorphism> morphisms;
       for (int i = 0; i < size; ++i)
@@ -501,7 +499,7 @@ TEST_F(EndomorphismSLPTest, SimpleAutomorphismsInvertionTest) {
       auto id = e * e_inverse;
 
       id.for_each_non_trivial_image([] (const EMorphism::symbol_image_pair_type& pair) {
-        ASSERT_EQ(slp::TerminalVertexTemplate<int>(pair.first), slp::reduce(pair.second));
+        ASSERT_EQ(slp::TerminalVertex(pair.first), slp::reduce(pair.second));
       });
 
     }
@@ -544,7 +542,7 @@ TEST_F(EndomorphismSLPTest, EqualityTest) {
   EXPECT_EQ(e, e);
 
   for (auto rank : {5, 10, 15}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10, 20}) {
       for (int i = 0; i < 10; ++i) {
         auto e = EMorphism::composition(size, rnd);
@@ -593,9 +591,9 @@ TEST_F(EndomorphismSLPTest, SmallSamplesConjugationTest) {
 
 TEST_F(EndomorphismSLPTest, ConjugationTest) {
   for (auto rank : {15, 10, 20, 30}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {0, 5, 10, 20}) {
-      auto conj = EndomorphismSLP<int>::identity().conjugate_with(size, rnd);
+      auto conj = EndomorphismSLP::identity().conjugate_with(size, rnd);
       ASSERT_TRUE(conj.is_identity());
     }
   }
@@ -603,7 +601,7 @@ TEST_F(EndomorphismSLPTest, ConjugationTest) {
 
 
 TEST_F(EndomorphismSLPTest, GeneratorDistributionTest) {
-  UniformAutomorphismSLPGenerator<int> rnd(5);
+  UniformAutomorphismSLPGenerator<> rnd(5);
   unsigned int inverter_num = 0;
   unsigned int multipliers_num = 0;
   const int num = 100000;
@@ -705,7 +703,7 @@ TEST_F(EndomorphismSLPTest, SaveAndLoad) {
     });
   }
   for (auto rank : {5, 10}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {5, 10, 20, 50}) {
       for (int i = 0; i < 10; ++i)
         check_save_load(EMorphism::composition(size, rnd));
@@ -715,10 +713,10 @@ TEST_F(EndomorphismSLPTest, SaveAndLoad) {
 
 
 TEST_F(EndomorphismSLPTest, CompositionSizeTest) {
-  UniformAutomorphismSLPGenerator<int> rnd(3);
+  UniformAutomorphismSLPGenerator<> rnd(3);
   for (int i = 0; i < 100; ++i) {
-    EndomorphismSLP<int> e = EndomorphismSLP<int>::composition(100, rnd);
-    EndomorphismSLP<int> e1 = EndomorphismSLP<int>::composition(100, rnd);
+    EndomorphismSLP e = EndomorphismSLP::composition(100, rnd);
+    EndomorphismSLP e1 = EndomorphismSLP::composition(100, rnd);
 
     auto sum = slp_vertices_num(e) + slp_vertices_num(e1);
     assert(sum >= slp_vertices_num(e * e1));
@@ -739,7 +737,7 @@ TEST_F(EndomorphismSLPTest, AutomorphismDescriptionBasicTest) {
   });
 
   for (auto rank : {3, 5, 10}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {5, 10}) {
       for (int i = 0; i < 10; ++i) {
         AutomorphismDescription<> a(size, rnd);
@@ -785,21 +783,21 @@ TEST_F(EndomorphismSLPTest, MakeCommutatorTest) {
     EXPECT_TRUE(comm.inverse().is_identity());
   });
 
-  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP<int>::inverter(1)),
-                         AutomorphismDescription<>(EndomorphismSLP<int>::inverter(2)));
+  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP::inverter(1)),
+                         AutomorphismDescription<>(EndomorphismSLP::inverter(2)));
   EXPECT_TRUE(comm().is_identity());
   EXPECT_TRUE(comm.inverse().is_identity());
 
-  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP<int>::right_multiplier(1, 2)),
-                         AutomorphismDescription<>(EndomorphismSLP<int>::inverter(1)));
+  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP::right_multiplier(1, 2)),
+                         AutomorphismDescription<>(EndomorphismSLP::inverter(1)));
 
   EXPECT_EQ(1, comm().non_trivial_images_num());
   EXPECT_EQ(1, comm.inverse().non_trivial_images_num());
   EXPECT_EQ("212", to_string(comm().image_word(1)));
   EXPECT_EQ("-21-2", to_string(comm.inverse().image_word(1)));
 
-  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP<int>::left_multiplier(1, 2)),
-                         AutomorphismDescription<>(EndomorphismSLP<int>::inverter(1)));
+  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP::left_multiplier(1, 2)),
+                         AutomorphismDescription<>(EndomorphismSLP::inverter(1)));
 
   EXPECT_EQ(1, comm().non_trivial_images_num());
   EXPECT_EQ(1, comm.inverse().non_trivial_images_num());
@@ -807,8 +805,8 @@ TEST_F(EndomorphismSLPTest, MakeCommutatorTest) {
   EXPECT_EQ("-1-12", to_string(comm.inverse().image_word(2)));
 
 
-  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP<int>::left_multiplier(1, 2)),
-                         AutomorphismDescription<>(EndomorphismSLP<int>::right_multiplier(1, 3)));
+  comm = make_commutator(AutomorphismDescription<>(EndomorphismSLP::left_multiplier(1, 2)),
+                         AutomorphismDescription<>(EndomorphismSLP::right_multiplier(1, 3)));
 
   EXPECT_EQ(2, comm().non_trivial_images_num());
   EXPECT_EQ(2, comm.inverse().non_trivial_images_num());
@@ -822,7 +820,7 @@ TEST_F(EndomorphismSLPTest, MakeCommutatorTest) {
 
 TEST_F(EndomorphismSLPTest, FreeReductionTest) {
   for (auto rank : {3, 5}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {50}) {
       for (int i = 0; i < 10; ++i) {
         auto e = EMorphism::composition(size, rnd).free_reduction();
@@ -833,7 +831,7 @@ TEST_F(EndomorphismSLPTest, FreeReductionTest) {
 
 TEST_F(EndomorphismSLPTest, FreeReductionPreciseTest) {
   for (auto rank : {3, 5, 10}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {50}) {
       for (int i = 0; i < 10; ++i) {
         auto e = EMorphism::composition(size, rnd).free_reduction_precise();
@@ -844,7 +842,7 @@ TEST_F(EndomorphismSLPTest, FreeReductionPreciseTest) {
 
 TEST_F(EndomorphismSLPTest, NormalFormTest) {
   for (auto rank : {3, 5, 10}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {30}) {
       for (int i = 0; i < 10; ++i) {
         auto e = EMorphism::composition(size, rnd);
@@ -857,7 +855,7 @@ TEST_F(EndomorphismSLPTest, NormalFormTest) {
 
 TEST_F(EndomorphismSLPTest, RemoveDuplicatesTest) {
   for (auto rank : {3, 5, 10}) {
-    UniformAutomorphismSLPGenerator<int> rnd(rank);
+    UniformAutomorphismSLPGenerator<> rnd(rank);
     for (auto size : {30}) {
       for (int i = 0; i < 10; ++i) {
         auto e = EMorphism::composition(size, rnd);

--- a/FreeGroup/test/FGACryptoTest.cpp
+++ b/FreeGroup/test/FGACryptoTest.cpp
@@ -38,7 +38,7 @@ namespace fga_crypto {
 //    gmp_pool_setup();
     std::default_random_engine rnd(2235);
     for (int i = 0; i < 10; ++i) {
-      UniformAutomorphismSLPGenerator<int> aut_random(3, &rnd);
+      UniformAutomorphismSLPGenerator<> aut_random(3, &rnd);
       AutDescription a_private_key(3, aut_random);
       AutDescription b_private_key(3, aut_random);
 
@@ -59,7 +59,7 @@ namespace fga_crypto {
 
     for (int i = 0; i < 5; ++i) {
       KeysGenerator real(params, rnd);
-      UniformAutomorphismSLPGenerator<int> aut_random(3, &rnd);
+      UniformAutomorphismSLPGenerator<> aut_random(3, &rnd);
       AutDescription mock_private_key(3, aut_random);
 
       MockParticipant mock(mock_private_key, real.private_key());

--- a/FreeGroup/test/slp_common_prefix.cpp
+++ b/FreeGroup/test/slp_common_prefix.cpp
@@ -21,10 +21,8 @@ namespace crag {
 namespace slp {
 namespace {
 
-typedef TerminalVertexTemplate<char> TerminalVertex;
-
 TEST(CommonPrefix, Trivial) {
-  TerminalVertex a('a');
+  TerminalVertex a(TerminalSymbol() + 1);
   NonterminalVertex aa(a, a);
 
   EXPECT_EQ(1, longest_common_prefix(a, a));
@@ -33,7 +31,7 @@ TEST(CommonPrefix, Trivial) {
 }
 
 TEST(CommonPrefix, Example1) {
-  TerminalVertex a('a');
+  TerminalVertex a(TerminalSymbol() + 1);
   NonterminalVertex aa(a, a);
   NonterminalVertex a3left(aa, a);
   NonterminalVertex a3right(a, aa);
@@ -46,8 +44,8 @@ TEST(CommonPrefix, Example1) {
 }
 
 TEST(CommonPrefix, Example2) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(TerminalSymbol() + 1);
+  TerminalVertex b(TerminalSymbol() + 2);
   NonterminalVertex aa(a, a);
   NonterminalVertex ab(a, b);
   MatchingTable matching_table;
@@ -58,8 +56,8 @@ TEST(CommonPrefix, Example2) {
 }
 
 TEST(CommonPrefix, Example3) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(TerminalSymbol() + 1);
+  TerminalVertex b(TerminalSymbol() + 2);
   NonterminalVertex ab(a, b);
   NonterminalVertex b1ab(ab.negate(), b);
   NonterminalVertex bb1ab(b, b1ab);
@@ -77,8 +75,8 @@ TEST(CommonPrefix, Example3) {
 
 
 Vertex get_random_slp_on_2_letters(unsigned int WORD_SIZE) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(TerminalSymbol() + 1);
+  TerminalVertex b(TerminalSymbol() + 2);
 
   int random_word = rand() % (1 << WORD_SIZE);
   std::vector<unsigned int> random_word_split;
@@ -120,11 +118,11 @@ TEST(GetPrefix, StressTest) {
   int repeat = 10000;
   while (--repeat >= 0) {
     Vertex slp = get_random_slp_on_2_letters(size);
-    std::string slp_string(VertexWord<char>(slp).begin(), VertexWord<char>(slp).end());
+    std::string slp_string(VertexWord(slp).begin(), VertexWord(slp).end());
     for (size_t prefix_length = 1; prefix_length < size; ++prefix_length) {
       Vertex prefix = get_prefix(slp, prefix_length);
       ASSERT_EQ(prefix_length, prefix.length());
-      std::string prefix_string(VertexWord<char>(prefix).begin(), VertexWord<char>(prefix).end());
+      std::string prefix_string(VertexWord(prefix).begin(), VertexWord(prefix).end());
       ASSERT_EQ(slp_string.substr(0, prefix_length), prefix_string);
     }
   }

--- a/FreeGroup/test/slp_inspector.cpp
+++ b/FreeGroup/test/slp_inspector.cpp
@@ -18,8 +18,6 @@
 namespace crag {
 namespace slp {
 namespace {
-  typedef TerminalVertexTemplate<char> TerminalVertex;
-
   template <typename InspectorType>
   void check_inspector_path(InspectorType&& inspector, const ::std::vector<Vertex>& correct_path, const ::std::vector<LongInteger>& correct_length) {
     auto length = correct_length.begin();
@@ -40,16 +38,16 @@ namespace {
   }
 
   TEST(PostorderInspector, SameChildren) {
-    auto a = TerminalVertex('a');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
     auto a2 = NonterminalVertex(a, a);
 
     EXPECT_NO_FATAL_FAILURE(check_inspector_path(PostorderInspector(a2), ::std::vector<Vertex>({a, a, a2}), ::std::vector<LongInteger>({0, 1, 0})));
   }
 
   TEST(PostorderInspector, LeftTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto ab = NonterminalVertex(a, b);
     auto abc = NonterminalVertex(ab, c);
@@ -58,9 +56,9 @@ namespace {
   }
 
   TEST(PostorderInspector, RightTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto bc = NonterminalVertex(b, c);
     auto abc = NonterminalVertex(a, bc);
@@ -69,8 +67,8 @@ namespace {
   }
 
   TEST(PostorderInspector, CrossedTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
 
     auto ab = NonterminalVertex(a, b);
     auto ba_1 = NonterminalVertex(b, a.negate());
@@ -90,16 +88,16 @@ namespace {
   }
 
   TEST(InorderInspector, SameChildren) {
-    auto a = TerminalVertex('a');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
     auto a2 = NonterminalVertex(a, a);
 
     EXPECT_NO_FATAL_FAILURE(check_inspector_path(InorderInspector(a2), ::std::vector<Vertex>({a, a2, a}), ::std::vector<LongInteger>({0, 0, 1})));
   }
 
   TEST(InorderInspector, LeftTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto ab = NonterminalVertex(a, b);
     auto abc = NonterminalVertex(ab, c);
@@ -108,9 +106,9 @@ namespace {
   }
 
   TEST(InorderInspector, RightTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto bc = NonterminalVertex(b, c);
     auto abc = NonterminalVertex(a, bc);
@@ -119,8 +117,8 @@ namespace {
   }
 
   TEST(InorderInspector, CrossedTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
 
     auto ab = NonterminalVertex(a, b);
     auto ba_1 = NonterminalVertex(b, a.negate());
@@ -140,16 +138,16 @@ namespace {
   }
 
   TEST(PreorderInspector, SameChildren) {
-    auto a = TerminalVertex('a');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
     auto a2 = NonterminalVertex(a, a);
 
     EXPECT_NO_FATAL_FAILURE(check_inspector_path(PreorderInspector(a2), ::std::vector<Vertex>({a2, a, a}), ::std::vector<LongInteger>({0, 0, 1})));
   }
 
   TEST(PreorderInspector, LeftTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto ab = NonterminalVertex(a, b);
     auto abc = NonterminalVertex(ab, c);
@@ -158,9 +156,9 @@ namespace {
   }
 
   TEST(PreorderInspector, RightTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
-    auto c = TerminalVertex('c');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
+    auto c = TerminalVertex(TerminalSymbol() + 3);
 
     auto bc = NonterminalVertex(b, c);
     auto abc = NonterminalVertex(a, bc);
@@ -169,8 +167,8 @@ namespace {
   }
 
   TEST(PreorderInspector, CrossedTree) {
-    auto a = TerminalVertex('a');
-    auto b = TerminalVertex('b');
+    auto a = TerminalVertex(TerminalSymbol() + 1);
+    auto b = TerminalVertex(TerminalSymbol() + 2);
 
     auto ab = NonterminalVertex(a, b);
     auto ba_1 = NonterminalVertex(b, a.negate());

--- a/FreeGroup/test/slp_pattern_matching.cpp
+++ b/FreeGroup/test/slp_pattern_matching.cpp
@@ -20,8 +20,6 @@
 namespace crag {
 namespace slp {
 namespace {
-typedef TerminalVertexTemplate<char> TerminalVertex;
-
 typedef ::std::tuple<int, int, int, int, ::std::vector<int>> BoundedTaskAcceptorTestParam;
 
 class BoundedTaskAcceptorTest : public ::testing::TestWithParam<BoundedTaskAcceptorTestParam>
@@ -36,7 +34,7 @@ TEST_P(BoundedTaskAcceptorTest, CheckOrder) {
 
   ::std::tie(pattern_code, text_code, lookup_from_int, lookup_length_int, correct_path) = GetParam();
 
-  TerminalVertex t('t');
+  TerminalVertex t(TerminalSymbol{} + 1);
   NonterminalVertex t2(t, t);
   NonterminalVertex t4(t2, t2);
 
@@ -115,7 +113,7 @@ class FilledMatchingTable : public MatchingTable {
       PostorderInspector text_inspector(text);
 
       while (!text_inspector.stopped()) {
-        VertexWord<char> current_text_word(text_inspector.vertex());
+        VertexWord current_text_word(text_inspector.vertex());
         std::string current_text(current_text_word.begin(), current_text_word.end());
 
         PostorderInspector pattern_inspector(pattern);
@@ -124,7 +122,7 @@ class FilledMatchingTable : public MatchingTable {
 
           if (pattern_inspector.vertex().length() <= text_inspector.vertex().length() &&
               match_table_->find(::std::make_pair(pattern_inspector.vertex(), text_inspector.vertex())) == match_table_->end()) {
-            VertexWord<char> current_pattern_word(pattern_inspector.vertex());
+            VertexWord current_pattern_word(pattern_inspector.vertex());
             std::string current_pattern(current_pattern_word.begin(), current_pattern_word.end());
             size_t current_match = text_inspector.vertex().split_point().get_ui() -
                 pattern_inspector.vertex().length().get_ui();
@@ -384,8 +382,8 @@ TEST(LocalSearch, RandomWord) {
     auto pattern_tree_string = print_tree_preorder(pattern);
     auto text_tree_string = print_tree_preorder(text);
 
-    ::std::string pattern_string(VertexWord<char>(pattern).begin(), VertexWord<char>(pattern).end());
-    ::std::string text_string(VertexWord<char>(text).begin(), VertexWord<char>(text).end());
+    ::std::string pattern_string(VertexWord(pattern).begin(), VertexWord(pattern).end());
+    ::std::string text_string(VertexWord(text).begin(), VertexWord(text).end());
 
     unsigned int last_match_position = left_boundary;
 
@@ -601,8 +599,8 @@ TEST(SLPMatchingTable, StressTest) {
       while (!pattern.stopped()) {
         ++pattern_vertex_number;
         ASSERT_EQ(computed_matching_table.matches(pattern.vertex(), text.vertex()), real_matching_table.matches(pattern.vertex(), text.vertex()))
-          << "pattern " << VertexWord<char>(pattern.vertex()) << ::std::endl << print_tree_preorder(pattern.vertex()) << ::std::endl << ::std::endl
-          << "text " << VertexWord<char>(text.vertex()) << ::std::endl << print_tree_preorder(text.vertex()) << ::std::endl << ::std::endl;
+          << "pattern " << VertexWord(pattern.vertex()) << ::std::endl << print_tree_preorder(pattern.vertex()) << ::std::endl << ::std::endl
+          << "text " << VertexWord(text.vertex()) << ::std::endl << print_tree_preorder(text.vertex()) << ::std::endl << ::std::endl;
         pattern.next();
       }
       text.next();

--- a/FreeGroup/test/slp_recompression_test.cpp
+++ b/FreeGroup/test/slp_recompression_test.cpp
@@ -16,7 +16,6 @@ namespace slp {
 namespace recompression {
 namespace {
 
-typedef TerminalVertexTemplate<int> TerminalVertex;
 std::string print_tree_preorder_single(const Vertex& vertex) {
   std::ostringstream out;
   std::unordered_set<slp::Vertex> printed;
@@ -123,28 +122,28 @@ TEST(Recompression, NormalForm) {
   Vertex normal_form_ab = normal_form(ab);
   EXPECT_EQ(a, normal_form_ab.left_child());
   EXPECT_EQ(b, normal_form_ab.right_child());
-  EXPECT_EQ(VertexWord<int>(ab), VertexWord<int>(normal_form_ab));
+  EXPECT_EQ(VertexWord(ab), VertexWord(normal_form_ab));
 
   Vertex normal_form_aa = normal_form(aa);
   EXPECT_EQ(a, normal_form_aa.left_child());
   EXPECT_EQ(a, normal_form_aa.right_child());
-  EXPECT_EQ(VertexWord<int>(aa), VertexWord<int>(normal_form_aa));
+  EXPECT_EQ(VertexWord(aa), VertexWord(normal_form_aa));
 
   Vertex normal_form_aab = normal_form(aab);
   EXPECT_EQ(a, normal_form_aab.left_child().left_child());
   EXPECT_EQ(a, normal_form_aab.left_child().right_child());
   EXPECT_EQ(b, normal_form_aab.right_child());
-  EXPECT_EQ(VertexWord<int>(aab), VertexWord<int>(normal_form_aab));
+  EXPECT_EQ(VertexWord(aab), VertexWord(normal_form_aab));
 
   Vertex normal_form_aabaa = normal_form(aabaa);
   EXPECT_EQ(normal_form_aabaa.right_child().right_child(), normal_form_aabaa.left_child());
   EXPECT_EQ(a, normal_form_aabaa.left_child().left_child());
   EXPECT_EQ(a, normal_form_aabaa.left_child().right_child());
   EXPECT_EQ(b, normal_form_aabaa.right_child().left_child());
-  EXPECT_EQ(VertexWord<int>(aabaa), VertexWord<int>(normal_form_aabaa));
+  EXPECT_EQ(VertexWord(aabaa), VertexWord(normal_form_aabaa));
 
   Vertex normal_form_aaba = normal_form(aaba);
-  EXPECT_EQ(VertexWord<int>(aaba), VertexWord<int>(normal_form_aaba));
+  EXPECT_EQ(VertexWord(aaba), VertexWord(normal_form_aaba));
 }
 
 Vertex vertex_power(Vertex base, size_t power) {
@@ -239,7 +238,7 @@ greedy_pairs(std::set<std::pair<int, int>> pairs) {
 
 std::tuple<std::vector<Vertex>, std::vector<int>>
 get_initial_rule(const Vertex& slp) {
-  VertexWord<int> vertex_word(slp);
+  VertexWord vertex_word(slp);
 
   std::vector<Vertex> terminal_vertex;
   terminal_vertex.emplace_back();
@@ -394,7 +393,7 @@ std::vector<int> compress_pairs(
 }
 
 Vertex normal_form(const Vertex& slp) {
-  VertexWord<int> vertex_word(slp);
+  VertexWord vertex_word(slp);
 
   std::vector<Vertex> terminal_vertex;
   std::vector<int> word;
@@ -441,10 +440,10 @@ void debug_print_exposed(const std::vector<int>& word, ::std::ostream* os, int s
 } //namespace naive_Jez
 
 ::testing::AssertionResult is_normal_form(Vertex slp, Vertex normal_form) {
-  if (VertexWord<int>(slp) != VertexWord<int>(normal_form)) {
+  if (VertexWord(slp) != VertexWord(normal_form)) {
     return ::testing::AssertionFailure() <<
         "Represented words are different" << std::endl <<
-        VertexWord<int>(slp) << " != " << VertexWord<int>(normal_form) << std::endl;
+        VertexWord(slp) << " != " << VertexWord(normal_form) << std::endl;
   }
   Vertex naive_normal = naive_Jez::normal_form(slp);
 
@@ -456,8 +455,8 @@ void debug_print_exposed(const std::vector<int>& word, ::std::ostream* os, int s
       return testing::AssertionFailure();
     }
 
-    VertexWord<int> correct_word(second_inspector.vertex());
-    VertexWord<int> computed_word(first_inspector.vertex());
+    VertexWord correct_word(second_inspector.vertex());
+    VertexWord computed_word(first_inspector.vertex());
 
     if (correct_word != computed_word) {
       return ::testing::AssertionFailure() << "Different normal forms" <<
@@ -1099,10 +1098,10 @@ TEST(Recompression, StressNormalForm) {
 
       auto inserted = hashes.insert(hash);
 
-      ASSERT_TRUE(inserted.second) << VertexWord<int>(inspector.vertex());
+      ASSERT_TRUE(inserted.second) << VertexWord(inspector.vertex());
 
 //      if (!inserted.second) {
-//        VertexWord<int> word(inspector.vertex());
+//        VertexWord word(inspector.vertex());
 //        auto terminal = word[0];
 //
 //        for (auto& symbol : word) {
@@ -1127,7 +1126,7 @@ TEST(Recompression, StressEndomorphismNormal) {
   int REPEAT = 1000;
   size_t seed = 112233;
   srand(seed);
-  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
   generator.set_inverters_probability(0);
 
   typedef crag::slp::TVertexHashAlgorithms<
@@ -1136,7 +1135,7 @@ TEST(Recompression, StressEndomorphismNormal) {
   > VertexHashAlgorithms;
 
   while (--REPEAT >= 0) {
-    Vertex slp = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    Vertex slp = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
     //std::cout << print_rules(slp) << std::endl;
     Vertex normal_slp = normal_form(slp);
 
@@ -1179,9 +1178,9 @@ TEST(Recompression, StressEndomorphismNormal) {
           << print_rules(slp) << "\n\n"
           << print_tree_preorder_single(inserted.first->second) << "\n"
           << print_tree_preorder_single(inspector.vertex()) << "\n"
-          << VertexWord<int>(inspector.vertex());
+          << VertexWord(inspector.vertex());
 //      if (!inserted.second) {
-//        VertexWord<int> word(inspector.vertex());
+//        VertexWord word(inspector.vertex());
 //        auto terminal = word[0];
 //
 //        for (auto& symbol : word) {
@@ -1190,7 +1189,7 @@ TEST(Recompression, StressEndomorphismNormal) {
 //              << print_rules(slp) << "\n\n"
 //              << print_tree_preorder_single(inserted.first->second) << "\n"
 //              << print_tree_preorder_single(inspector.vertex()) << "\n"
-//              << VertexWord<int>(inspector.vertex());
+//              << VertexWord(inspector.vertex());
 //        }
 //      }
 

--- a/FreeGroup/test/slp_reduce.cpp
+++ b/FreeGroup/test/slp_reduce.cpp
@@ -24,11 +24,12 @@ namespace crag {
 namespace slp {
 namespace {
 
-typedef TerminalVertexTemplate<char> TerminalVertex;
+constexpr TerminalSymbol terminal_a = TerminalSymbol{} + 1;
+constexpr TerminalSymbol terminal_b = TerminalSymbol{} + 2;
 
 Vertex get_random_slp_on_2_letters(unsigned int WORD_SIZE) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(terminal_a);
+  TerminalVertex b(terminal_b);
 
   int random_word = rand() % (1 << WORD_SIZE);
   std::vector<unsigned int> random_word_split;
@@ -58,11 +59,11 @@ Vertex get_random_slp_on_2_letters(unsigned int WORD_SIZE) {
 //  int repeat = 1;
 //  while (--repeat >= 0) {
 //    Vertex slp = get_random_slp_on_2_letters(size);
-//    std::string slp_string(VertexWord<char>(slp).begin(), VertexWord<char>(slp).end());
+//    std::string slp_string(VertexWord(slp).begin(), VertexWord(slp).end());
 //    for (size_t start = 1; start < size; ++start) {
 //      for (size_t end = start + 1; end <= size; ++end) {
 //        Vertex sub_slp = get_sub_slp(slp, start, end);
-//        std::string subslp_string(VertexWord<char>(sub_slp).begin(), VertexWord<char>(sub_slp).end());
+//        std::string subslp_string(VertexWord(sub_slp).begin(), VertexWord(sub_slp).end());
 //        ASSERT_EQ(slp_string.substr(start, end - start), subslp_string) << slp_string << '[' << start << ':' <<end << ']';
 //      }
 //    }
@@ -75,7 +76,7 @@ TEST(SubSLP, StressTest) {
   srand(time(0));
   while (--repeat >= 0) {
     Vertex slp = get_random_slp_on_2_letters(size);
-    std::string slp_string(VertexWord<char>(slp).begin(), VertexWord<char>(slp).end());
+    std::string slp_string(VertexWord(slp).begin(), VertexWord(slp).end());
     size_t start = 0;
     size_t end = 0;
     while (start == end) {
@@ -86,7 +87,7 @@ TEST(SubSLP, StressTest) {
       }
     }
     Vertex sub_slp = get_sub_slp(slp, start, end);
-    std::string subslp_string(VertexWord<char>(sub_slp).begin(), VertexWord<char>(sub_slp).end());
+    std::string subslp_string(VertexWord(sub_slp).begin(), VertexWord(sub_slp).end());
     ASSERT_EQ(slp_string.substr(start, end - start), subslp_string) << slp_string << '[' << start << ':' <<end << ']';
 
     PreorderInspector inspector(sub_slp);
@@ -99,16 +100,16 @@ TEST(SubSLP, StressTest) {
 }
 
 TEST(Reduce, Simple1) {
-  TerminalVertex a('a');
-  TerminalVertex a_(-'a');
+  TerminalVertex a(terminal_a);
+  TerminalVertex a_(-terminal_a);
   NonterminalVertex mNull(a, a_);
 
   EXPECT_EQ(Vertex(), reduce(mNull));
 }
 
 TEST(Reduce, Simple2) {
-  TerminalVertex a('a');
-  TerminalVertex b('b');
+  TerminalVertex a(terminal_a);
+  TerminalVertex b(terminal_b);
   NonterminalVertex ab(a, b);
   NonterminalVertex b_1a_1(b.negate(), a.negate());
   NonterminalVertex mNull(ab, b_1a_1);
@@ -159,21 +160,21 @@ std::string print_tree_preorder_single(const Vertex& vertex) {
 
 
 TEST(Reduce, Example1) {
-  TerminalVertexTemplate<int> v1(1);
-  TerminalVertexTemplate<int> v2(2);
+  TerminalVertex v1(1);
+  TerminalVertex v2(2);
   NonterminalVertex v9(v1, v2);
   Vertex v12 = NonterminalVertex(v2, v9).negate();
   NonterminalVertex v13(v2, v12);
   auto reduced = reduce(v13);
   int previous = 0;
-  for (auto symbol : VertexWord<int>(reduced)) {
+  for (auto symbol : VertexWord(reduced)) {
     EXPECT_NE(-previous, symbol) << print_tree_preorder(reduced);
     previous = symbol;
   }
 }
-//TerminalVertexTemplate<int> t1(1);
-//TerminalVertexTemplate<int> t2(2);
-//TerminalVertexTemplate<int> t3(3);
+//TerminalVertex t1(1);
+//TerminalVertex t2(2);
+//TerminalVertex t3(3);
 //NonterminalVertex v1(t1, t2);
 //NonterminalVertex v2(v1, t3);
 //NonterminalVertex v3(t1, v2);
@@ -188,9 +189,9 @@ TEST(Reduce, Example1) {
 //std::vector<int> correct = {-3, -2, -1, -3, -2, -1, 2, 3, 3, 3};
 
 TEST(Reduce, Example2) {
-  TerminalVertexTemplate<int> t1(1);
-  TerminalVertexTemplate<int> t2(2);
-  TerminalVertexTemplate<int> t3(3);
+  TerminalVertex t1(1);
+  TerminalVertex t2(2);
+  TerminalVertex t3(3);
   NonterminalVertex v1(t1, t2);
   NonterminalVertex v2(v1, t3);
   NonterminalVertex v3(t1, v2);
@@ -205,7 +206,7 @@ TEST(Reduce, Example2) {
   auto reduced = reduce(v8);
   ASSERT_EQ(correct.size(), reduced.length());
   auto correct_symbol = correct.begin();
-  for (auto symbol : VertexWord<int>(reduced)) {
+  for (auto symbol : VertexWord(reduced)) {
     ASSERT_EQ(*correct_symbol, symbol);
     ++correct_symbol;
   }
@@ -218,13 +219,13 @@ TEST(Reduce, StressTest) {
   const size_t ENDOMORPHISMS_NUMBER = 20;
   size_t seed = 0;
   while (++seed <= REPEAT) {
-    UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    UniformAutomorphismSLPGenerator<> generator(RANK, seed);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
     Vertex reduced = reduce(image);
 
     std::vector<int> reduced_image;
-    for (auto symbol : VertexWord<int>(reduced)) {
+    for (auto symbol : VertexWord(reduced)) {
       if (!reduced_image.empty() && symbol == -reduced_image.back()) {
         reduced_image.pop_back();
       } else {
@@ -234,12 +235,12 @@ TEST(Reduce, StressTest) {
     std::ostringstream reduced_image_string;
     std::copy(reduced_image.begin(), reduced_image.end(), std::ostream_iterator<int>(reduced_image_string, ""));
     auto correct_symbol = reduced_image.begin();
-    for (auto symbol : VertexWord<int>(reduced)) {
+    for (auto symbol : VertexWord(reduced)) {
       ASSERT_EQ(*correct_symbol, symbol) << seed << std::endl
           << print_tree_preorder_single(image) << std::endl
           << print_tree_preorder(reduced) << std::endl
-          << VertexWord<int>(image) << std::endl
-          << VertexWord<int>(reduced) << std::endl
+          << VertexWord(image) << std::endl
+          << VertexWord(reduced) << std::endl
           << reduced_image_string.str() << std::endl;
       ++correct_symbol;
     }
@@ -251,9 +252,9 @@ TEST(Reduce, StressTest) {
 //  const size_t RANK = 3;
 //  const size_t ENDOMORPHISMS_NUMBER = 100;
 //  size_t seed = 112233;///time(0);//
-//  UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
+//  UniformAutomorphismSLPGenerator<> generator(RANK, seed);
 //  while (--REPEAT >= 0) {
-//    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).slp(1);
+//    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).slp(1);
 //
 //    Vertex reduced = reduce(image);
 //    std::cout << image.length() << std::endl;

--- a/FreeGroup/test/slp_vertex.cpp
+++ b/FreeGroup/test/slp_vertex.cpp
@@ -16,13 +16,16 @@ namespace crag {
 namespace slp {
 namespace {
 
-typedef TerminalVertexTemplate<char> TerminalVertex;
+constexpr TerminalSymbol terminal_a = TerminalSymbol{} + 100;
+constexpr TerminalSymbol terminal_b = TerminalSymbol{} + 200;
+constexpr TerminalSymbol terminal_c = TerminalSymbol{} + 300;
+
 class VertexTest : public ::testing::Test {
   protected:
     VertexTest()
-      : a(TerminalVertex('a'))
-      , b(TerminalVertex('b'))
-      , c(TerminalVertex('c'))
+      : a(TerminalVertex(terminal_a))
+      , b(TerminalVertex(terminal_b))
+      , c(TerminalVertex(terminal_c))
     { }
 
     Vertex a;
@@ -62,12 +65,12 @@ TEST_F(VertexTest, TerminalVertex) {
   EXPECT_NE(a, a.negate());
   EXPECT_EQ(a, a);
   EXPECT_EQ(a, a.negate().negate());
-  EXPECT_EQ('a', TerminalVertex(a));
-  EXPECT_EQ(-'a', TerminalVertex(a.negate()).terminal_symbol());
+  EXPECT_EQ(terminal_a, TerminalVertex(a));
+  EXPECT_EQ(-terminal_a, TerminalVertex(a.negate()).terminal_symbol());
 
   TerminalVertex typed_a(a);
-  EXPECT_EQ('a', typed_a);
-  EXPECT_EQ(-'a', TerminalVertex(typed_a.negate()));
+  EXPECT_EQ(terminal_a, typed_a);
+  EXPECT_EQ(-terminal_a, TerminalVertex(typed_a.negate()));
 
   EXPECT_EQ(hash(a), hash(a.negate().negate()));
   EXPECT_NE(hash(a), hash(a.negate()));

--- a/FreeGroup/test/slp_vertex_hash.cpp
+++ b/FreeGroup/test/slp_vertex_hash.cpp
@@ -23,7 +23,7 @@ namespace {
 template <typename T>
 class HasherTest : public ::testing::Test {
   protected:
-    typedef TerminalVertexTemplate<int> TerminalVertex;
+    typedef slp::TerminalVertex TerminalVertex;
     TerminalVertex a;
     TerminalVertex b;
 
@@ -134,13 +134,13 @@ TEST(HashedReduce, StressTest) {
   typedef TVertexHashAlgorithms<hashers::SinglePowerHash, hashers::PermutationHash<Permutation16> > VertexHashAlgorithms;
   size_t seed = 0;
   while (++seed <= REPEAT) {
-    UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    UniformAutomorphismSLPGenerator<> generator(RANK, seed);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
     Vertex reduced = VertexHashAlgorithms::reduce(image);
 
     std::vector<int> reduced_image;
-    for (auto symbol : VertexWord<int>(image)) {
+    for (auto symbol : VertexWord(image)) {
       if (!reduced_image.empty() && symbol == -reduced_image.back()) {
         reduced_image.pop_back();
       } else {
@@ -150,12 +150,12 @@ TEST(HashedReduce, StressTest) {
     std::ostringstream reduced_image_string;
     std::copy(reduced_image.begin(), reduced_image.end(), std::ostream_iterator<int>(reduced_image_string, ""));
     auto correct_symbol = reduced_image.begin();
-    for (auto symbol : VertexWord<int>(reduced)) {
+    for (auto symbol : VertexWord(reduced)) {
       ASSERT_EQ(*correct_symbol, symbol) << seed << std::endl
           << print_tree_preorder_single(image) << std::endl
           << print_tree_preorder(reduced) << std::endl
-          << VertexWord<int>(image) << std::endl
-          << VertexWord<int>(reduced) << std::endl
+          << VertexWord(image) << std::endl
+          << VertexWord(reduced) << std::endl
           << reduced_image_string.str() << std::endl;
       ++correct_symbol;
     }
@@ -170,13 +170,13 @@ TEST(HashedReduceNarrow, StressTest) {
   typedef TVertexHashAlgorithms<hashers::SinglePowerHash, hashers::PermutationHash<Permutation16> > VertexHashAlgorithms;
   size_t seed = 0;
   while (++seed <= REPEAT) {
-    UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    UniformAutomorphismSLPGenerator<> generator(RANK, seed);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
     Vertex reduced = VertexHashAlgorithms::reduce_narrow_slp(image);
 
     std::vector<int> reduced_image;
-    for (auto symbol : VertexWord<int>(image)) {
+    for (auto symbol : VertexWord(image)) {
       if (!reduced_image.empty() && symbol == -reduced_image.back()) {
         reduced_image.pop_back();
       } else {
@@ -186,12 +186,12 @@ TEST(HashedReduceNarrow, StressTest) {
     std::ostringstream reduced_image_string;
     std::copy(reduced_image.begin(), reduced_image.end(), std::ostream_iterator<int>(reduced_image_string, ""));
     auto correct_symbol = reduced_image.begin();
-    for (auto symbol : VertexWord<int>(reduced)) {
+    for (auto symbol : VertexWord(reduced)) {
       ASSERT_EQ(*correct_symbol, symbol) << seed << std::endl
           << print_tree_preorder_single(image) << std::endl
           << print_tree_preorder(reduced) << std::endl
-          << VertexWord<int>(image) << std::endl
-          << VertexWord<int>(reduced) << std::endl
+          << VertexWord(image) << std::endl
+          << VertexWord(reduced) << std::endl
           << reduced_image_string.str() << std::endl;
       ++correct_symbol;
     }
@@ -212,8 +212,8 @@ TEST(HashedReduce, RemoveDuplicatesStressTest) {
   size_t seed = 0;
   size_t n_errors = 0;
   while (++seed <= REPEAT) {
-    UniformAutomorphismSLPGenerator<int> generator(RANK, seed);
-    auto image = EndomorphismSLP<int>::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
+    UniformAutomorphismSLPGenerator<> generator(RANK, seed);
+    auto image = EndomorphismSLP::composition(ENDOMORPHISMS_NUMBER, generator).image(1);
 
     ASSERT_EQ(VertexHashAlgorithms::get_vertex_hash(image), VertexHashAlgorithms::get_vertex_hash(image));
 
@@ -224,8 +224,8 @@ TEST(HashedReduce, RemoveDuplicatesStressTest) {
     ASSERT_EQ(image.length(), rd_mage.length());
 
     slp::MatchingTable mt;
-    VertexWord<int> image_word(image);
-    VertexWord<int> rd_word(rd_mage);
+    VertexWord image_word(image);
+    VertexWord rd_word(rd_mage);
     if(!image_word.is_equal_to(rd_word, &mt)) {
       ++n_errors;
     }

--- a/FreeGroup/test/slp_vertex_word.cpp
+++ b/FreeGroup/test/slp_vertex_word.cpp
@@ -17,90 +17,92 @@
 namespace crag {
 namespace slp {
 namespace {
-  typedef VertexWord<char> VertexCharWord;
-  typedef TerminalVertexTemplate<char> TerminalVertex;
+
+constexpr TerminalSymbol terminal_a = TerminalSymbol{} + 1;
+constexpr TerminalSymbol terminal_b = TerminalSymbol{} + 2;
+constexpr TerminalSymbol terminal_c = TerminalSymbol{} + 3;
 
   TEST(VertexWord, size) {
-    TerminalVertex a('a');
-    TerminalVertex b('a');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_a);
     NonterminalVertex ab(a, b);
 
-    EXPECT_EQ(0, VertexCharWord().size());
-    EXPECT_EQ(1, VertexCharWord(a).size());
-    EXPECT_EQ(2, VertexCharWord(ab).size());
+    EXPECT_EQ(0, VertexWord().size());
+    EXPECT_EQ(1, VertexWord(a).size());
+    EXPECT_EQ(2, VertexWord(ab).size());
   }
 
   TEST(VertexWord, IndexLeftTree) {
-    TerminalVertex a('a');
-    TerminalVertex b('b');
-    TerminalVertex c('c');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_b);
+    TerminalVertex c(terminal_c);
 
     NonterminalVertex ab(a, b);
     NonterminalVertex abc(ab, c);
 
-    VertexCharWord w(abc);
+    VertexWord w(abc);
 
     ASSERT_EQ(3, w.size());
-    EXPECT_EQ('a', w[0]);
-    EXPECT_EQ('b', w[1]);
-    EXPECT_EQ('c', w[2]);
+    EXPECT_EQ(terminal_a, w[0]);
+    EXPECT_EQ(terminal_b, w[1]);
+    EXPECT_EQ(terminal_c, w[2]);
   }
 
   TEST(VertexWord, IndexRightTree) {
-    TerminalVertex a('a');
-    TerminalVertex b('b');
-    TerminalVertex c('c');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_b);
+    TerminalVertex c(terminal_c);
 
     NonterminalVertex bc(b, c);
     NonterminalVertex abc(a, bc);
 
-    VertexCharWord w(abc);
+    VertexWord w(abc);
 
     ASSERT_EQ(3, w.size());
-    EXPECT_EQ('a', w[0]);
-    EXPECT_EQ('b', w[1]);
-    EXPECT_EQ('c', w[2]);
+    EXPECT_EQ(terminal_a, w[0]);
+    EXPECT_EQ(terminal_b, w[1]);
+    EXPECT_EQ(terminal_c, w[2]);
   }
 
   TEST(VertexWord, IndexCrossedTree) {
-    TerminalVertex a('a');
-    TerminalVertex b('b');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_b);
 
     NonterminalVertex ab(a, b);
     NonterminalVertex ba_1(b, a.negate());
 
     NonterminalVertex abab_1(ab, ba_1.negate());
 
-    VertexCharWord w(abab_1);
+    VertexWord w(abab_1);
 
     ASSERT_EQ(w.size(), 4);
-    EXPECT_EQ('a', w[0]);
-    EXPECT_EQ('b', w[1]);
-    EXPECT_EQ('a', w[2]);
-    EXPECT_EQ(-'b', w[3]);
+    EXPECT_EQ(terminal_a, w[0]);
+    EXPECT_EQ(terminal_b, w[1]);
+    EXPECT_EQ(terminal_a, w[2]);
+    EXPECT_EQ(-terminal_b, w[3]);
   }
 
   TEST(VertexWord, Iterator) {
-    TerminalVertex a('a');
-    TerminalVertex b('b');
-    TerminalVertex c('c');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_b);
+    TerminalVertex c(terminal_c);
 
     NonterminalVertex ab(a, b);
     NonterminalVertex abc(ab, c);
 
-    VertexCharWord w(abc);
+    VertexWord w(abc);
 
-    EXPECT_EQ("abc", ::std::string(w.begin(), w.end()));
-    EXPECT_EQ('a', *(w.begin() + 0));
-    EXPECT_EQ('b', *(w.begin() + 1));
-    EXPECT_EQ('c', *(w.begin() + 2));
+    EXPECT_EQ(::std::string({terminal_a, terminal_b, terminal_c}), ::std::string(w.begin(), w.end()));
+    EXPECT_EQ(terminal_a, *(w.begin() + 0));
+    EXPECT_EQ(terminal_b, *(w.begin() + 1));
+    EXPECT_EQ(terminal_c, *(w.begin() + 2));
   }
 
 
   TEST(VertexWord, StressTest) {
     const unsigned int word_size = 6;
-    TerminalVertex a('a');
-    TerminalVertex b('b');
+    TerminalVertex a(terminal_a);
+    TerminalVertex b(terminal_b);
 
     unsigned int current_word = 0;
     while (current_word < (1 << word_size)) {
@@ -108,7 +110,7 @@ namespace {
       std::string current_word_string;
 
       for (size_t i = 0; i < word_size; ++i) {
-        current_word_string.push_back((current_word & (1 << i)) ? 'b' : 'a');
+        current_word_string.push_back((current_word & (1 << i)) ? terminal_b : terminal_a);
       }
 
       for (unsigned int i = 1; i < word_size; ++i) {
@@ -118,7 +120,7 @@ namespace {
       do {
         std::vector<Vertex> word_presentation;
         for (char letter : current_word_string) {
-          word_presentation.push_back(letter == 'a' ? a : b);
+          word_presentation.push_back(letter == terminal_a ? a : b);
         }
 
         for (unsigned int split : current_word_split) {
@@ -132,7 +134,7 @@ namespace {
         const Vertex& current_slp = word_presentation.front();
         ASSERT_EQ(current_word_split.back(), current_slp.left_child().length().get_ui());
 
-        VertexCharWord word(current_slp);
+        VertexWord word(current_slp);
         ASSERT_EQ(current_word_string, std::string(word.begin(), word.end()));
 
         for (size_t i = 0; i < current_word_string.size(); ++i) {


### PR DESCRIPTION
Now TerminalSymbol is a typedef in slp_vertex.h. Looks like there are no benefits from using multiple types.
